### PR TITLE
Keep the vault in sync across ER topic merges (#54, #55, #56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,21 @@ Rules for tests you write:
 - Don't test LLM output *quality* in pytest — that's what the evaluation modules + MLflow are for.
   Tests assert plumbing (types, schemas, prompt formatting, metric math), evals assert quality.
 
+## Code style
+
+Bare-bones but modular: the minimal implementation that solves the task, structured so it's easy
+to extend later — not padded with flexibility for that later.
+
+- No speculative surface: no "might be useful later" parameters, return values, branches, or
+  abstractions. If nothing calls it, delete it — don't keep it "just in case."
+- Modular means correct boundaries, not extra options: a function owns one concern and queries its
+  own inputs rather than accepting precomputed state threaded in from a sibling. That's what makes
+  it reusable later without a refactor, not extra configurability now.
+- Two near-identical blocks (same shape, one differing parameter) become one parameterized
+  function/factory, not copy-paste-and-tweak.
+- Push work to the layer that does it best — e.g. a SQL join over hand-rolled Python-side
+  cross-referencing — instead of building intermediate structures to compensate.
+
 ## Conventions
 
 - Prefer an existing, well-established library over hand-rolled parsing/extraction logic (regex,

--- a/dsview/cli.py
+++ b/dsview/cli.py
@@ -204,6 +204,75 @@ def regen_vault():
             write_topic_note(topic)
 
 
+@app.command(
+    help="Check coherence between the database and the Obsidian vault (read-only)"
+)
+def check_vault_sync(
+    details: str = typer.Option(
+        None,
+        help="Print every discrepancy for a single category "
+        "(missing_note, orphan_file, missing_edge, extra_edge, unreadable_note)",
+    ),
+    kind: str = typer.Option(
+        None,
+        help="Restrict --details to one kind of node (content, topic, relation)",
+    ),
+    output: Path = typer.Option(
+        None,
+        help="Optional path to write the full itemized report to (not just the summary)",
+    ),
+):
+    """
+    Compare every content/topic note the database implies with what is actually on
+    disk in the vault. The database is always assumed correct; this only reports
+    discrepancies, it never modifies the database or the vault.
+    """
+    from rich.console import Console
+
+    from dsview.obsidian.check_vault_sync import check_vault_sync as run_check
+    from dsview.obsidian.check_vault_sync import (
+        format_report,
+        render_category_table,
+        render_summary_table,
+    )
+
+    with Session(db.engine) as session:
+        discrepancies, stats = run_check(session)
+
+    console = Console()
+
+    if stats.get("content_missing_extraction"):
+        console.print(
+            f"[dim]{stats['content_missing_extraction']} content row(s) have no "
+            "extraction yet - no note is expected for them, not counted below.[/dim]"
+        )
+
+    console.print(render_summary_table(discrepancies))
+
+    if details:
+        matching = [
+            d
+            for d in discrepancies
+            if d.category == details and (not kind or d.kind == kind)
+        ]
+        if not matching:
+            console.print(f"No discrepancies found in category '{details}'.")
+        else:
+            console.print(render_category_table(discrepancies, kind, details))
+    elif discrepancies:
+        console.print(
+            "[dim]Use --details <category> (optionally with --kind) to list "
+            "individual discrepancies.[/dim]"
+        )
+
+    if output:
+        output.write_text(format_report(discrepancies, stats))
+        console.print(f"Full itemized report written to {output}")
+
+    if discrepancies:
+        raise typer.Exit(code=1)
+
+
 @app.command(help="Reset database tables (with confirmation prompts)")
 def reset_db():
     """
@@ -223,18 +292,15 @@ def reset_db():
 
     logger.info(
         "This command will delete the following tables : %s",
-        ', '.join([t.__tablename__ for t in tables_to_drop])
+        ", ".join([t.__tablename__ for t in tables_to_drop]),
     )
 
     delete_extraction = typer.confirm("Clear extraction results ? ")
 
     if delete_extraction:
         logger.info("Deleting extraction results")
-        schemas.drop_tables(
-            tables_to_drop,
-            db.engine,
-            reset=True
-        )
+        schemas.drop_tables(tables_to_drop, db.engine, reset=True)
+
 
 @app.command(help="Clear the entire Obsidian vault (DESTRUCTIVE)")
 def reset_vault():

--- a/dsview/cli.py
+++ b/dsview/cli.py
@@ -1,19 +1,20 @@
 import logging
+import os
+import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Type
 
-import pandas as pd
 import typer
 from dotenv import load_dotenv
-from sqlmodel import Session, SQLModel
+from sqlmodel import Session
 
 from dsview import db
-from dsview.config import setup_logger
+from dsview.config import load_postgres_config, setup_logger
 from dsview.db import schemas
 from dsview.db.query import get_content_list, get_failed_ingestions, get_topic_list
 from dsview.db.schemas.extraction_schema import ExtractionResult
 from dsview.evaluation.cli import evaluate_app
+from dsview.obsidian.sync_vault import run_cmd
 from dsview.obsidian.write_notes import (
     write_content_note,
     write_topic_note,
@@ -37,36 +38,62 @@ def cli_setup():
 
 app.add_typer(evaluate_app, name="evaluate")
 
-BACKUP_TABLES = [
-    schemas.InputContent,
-    schemas.LabelledContent,
-    schemas.TitleLabels,
-    schemas.ContentTypeLabels,
-    schemas.TagLabels,
-    schemas.TopicsLabels,
-    schemas.LinksLabels,
-    schemas.ERLabels,
-]
+
+class MissingPostgresTool(Exception):
+    """Exception raised when pg_dump/pg_restore is not installed."""
+
+    def __init__(self, tool: str) -> None:
+        super().__init__(
+            f"'{tool}' not found on PATH. Install the postgresql-client package."
+        )
 
 
-@app.command(help="Backup database tables to parquet files in the backup directory")
+def _require_pg_tool(tool: str) -> str:
+    path = shutil.which(tool)
+    if path is None:
+        raise MissingPostgresTool(tool)
+    return path
+
+
+def _pg_connection_args() -> tuple[list[str], dict]:
+    pg_config = load_postgres_config()
+    args = [
+        "-h",
+        pg_config.host,
+        "-p",
+        str(pg_config.port),
+        "-U",
+        pg_config.user,
+        "-d",
+        pg_config.database,
+    ]
+    env = {**os.environ, "PGPASSWORD": pg_config.password}
+    return args, env
+
+
+@app.command(help="Backup the whole database to a pg_dump file in the backup directory")
 def backup():
     """
-    Create backup files for all important database tables.
-    Saves data as parquet files in a 'backup' directory.
+    Dump the entire database (all schemas/tables) with pg_dump so the backup
+    is exhaustive by construction and restore preserves ids/foreign keys.
     """
+    pg_dump = _require_pg_tool("pg_dump")
+
     backup_path = Path("backup")
+    backup_path.mkdir(exist_ok=True)
 
-    if not backup_path.exists():
-        backup_path.mkdir()
+    output_file = backup_path / f"dsview_{datetime.now():%Y%m%d_%H%M%S}.dump"
+    connection_args, env = _pg_connection_args()
 
-    for table in BACKUP_TABLES:
-        df = pd.read_sql(
-            f"SELECT * FROM {table.__table__}",
-            con=db.engine,
-        ).drop(columns=["id"])
+    run_cmd(
+        [pg_dump, "-Fc", "--no-owner", "--no-privileges"]
+        + connection_args
+        + ["-f", str(output_file)],
+        "pg_dump backup",
+        env=env,
+    )
 
-        df.to_parquet(backup_path / f"{table.__tablename__}.parquet")
+    logger.info("Backup written to %s", output_file)
 
 
 @app.command(help="Ingest a single piece of content from a URL or link")
@@ -358,44 +385,58 @@ class MissingBackupDirectory(Exception):
         super().__init__(f"No backup directory found at {path}")
 
 
-def restore_one_table(
-    backup_path: Path,
-    table: Type[SQLModel],
-    session,
-):
-    """
-    Restore a single table from a parquet backup file.
+class NoBackupFileFound(Exception):
+    """Exception raised when no dump file is found in the backup directory."""
 
-    Args:
-        backup_path: Path to the backup directory
-        table: SQLModel table class to restore
-        session: Database session
-    """
-    df = pd.read_parquet(backup_path / f"{table.__tablename__}.parquet")
-
-    instances = []
-    for _, row in df.iterrows():
-        instances.append(table(**row))
-    session.add_all(instances)
-    session.commit()
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"No '*.dump' file found in {path}")
 
 
-@app.command(help="Restore database tables from parquet backup files")
+def _latest_backup_file(backup_path: Path) -> Path:
+    dump_files = sorted(backup_path.glob("*.dump"), key=lambda f: f.stat().st_mtime)
+    if not dump_files:
+        raise NoBackupFileFound(backup_path)
+    return dump_files[-1]
+
+
+@app.command(help="Restore the database from a pg_dump backup file (DESTRUCTIVE)")
 def restore_db(
+    backup_file: str = typer.Option(
+        None,
+        help="Dump file to restore. Defaults to the most recent '*.dump' in --backup-dir",
+    ),
     backup_dir: str = typer.Option("backup", help="Directory containing backup files"),
 ):
     """
-    Restore database tables from parquet backup files.
-    This will restore all tables listed in BACKUP_TABLES from the specified directory.
+    Restore the database from a pg_dump backup file.
+    WARNING: this drops existing objects (pg_restore --clean) before recreating them.
     """
     backup_path = Path(backup_dir)
-
     if not backup_path.exists():
         raise MissingBackupDirectory(backup_path)
 
-    with Session(db.engine) as session:
-        for table in BACKUP_TABLES:
-            restore_one_table(backup_path, table, session)
+    dump_file = Path(backup_file) if backup_file else _latest_backup_file(backup_path)
+
+    delete = typer.confirm(
+        f"This will drop and recreate existing database objects from {dump_file}. "
+        "Are you sure you want to restore ?"
+    )
+    if not delete:
+        logger.info("Aborting restore")
+        raise typer.Abort()
+
+    pg_restore = _require_pg_tool("pg_restore")
+    connection_args, env = _pg_connection_args()
+
+    run_cmd(
+        [pg_restore, "--clean", "--if-exists", "--no-owner", "--no-privileges"]
+        + connection_args
+        + [str(dump_file)],
+        "pg_restore restore",
+        env=env,
+    )
+
+    logger.info("Database restored from %s", dump_file)
 
 
 @app.command(help="Export extraction results as a graph")

--- a/dsview/db/ingest/__init__.py
+++ b/dsview/db/ingest/__init__.py
@@ -5,9 +5,9 @@ from .ingest_content import (
     update_content,
 )
 from .ingest_extraction import (
+    build_er_comparison,
     embed_and_save_topic,
     embed_and_update_topic,
-    save_er_comparison,
     embed_and_format_extraction_results,
 )
 from .ingest_labels import save_er_label, save_labels, update_er_label

--- a/dsview/db/ingest/ingest_extraction.py
+++ b/dsview/db/ingest/ingest_extraction.py
@@ -101,17 +101,14 @@ async def embed_and_update_topic(
     return session.get(ExtractionTopic, topic_id)
 
 
-def save_er_comparison(
+def build_er_comparison(
     topic_1: DataScienceTopic,
     topic_2: DataScienceTopic,
     fts_score: float,
     vss_distance: float,
     result: ERResult,
-    session: Session,
-):
-    # Check if the comparison already exists in the database
-
-    er_comparison = ERComparison(
+) -> ERComparison:
+    return ERComparison(
         name_1=topic_1.name,
         type_1=topic_1.type,
         description_1=topic_1.description,
@@ -126,5 +123,3 @@ def save_er_comparison(
         merge_type=(result.topic.type if result.topic else None),
         merge_description=(result.topic.description if result.topic else None),
     )
-
-    session.add(er_comparison)

--- a/dsview/db/query/query_topic.py
+++ b/dsview/db/query/query_topic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from ..schemas import ExtractionTopic
@@ -71,7 +72,9 @@ class TopicsIndex(DuckDBIndex):
 
 
 def get_topic_by_name(name: str, session: Session) -> DataScienceTopic:
-    statement = select(ExtractionTopic).where(ExtractionTopic.name == name)
+    statement = select(ExtractionTopic).where(
+        func.lower(ExtractionTopic.name) == name.lower()
+    )
 
     return session.exec(statement).first()
 

--- a/dsview/db/schemas/extraction_schema.py
+++ b/dsview/db/schemas/extraction_schema.py
@@ -36,7 +36,7 @@ class ExtractionTag(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     content_id: int = Field(
-        foreign_key=f"{EXTRACTION_SCHEMA}.extractionresult.content_zid"
+        foreign_key=f"{EXTRACTION_SCHEMA}.extractionresult.content_id"
     )
     name: str
 
@@ -61,15 +61,9 @@ class ExtractionLink(SQLModel, table=True):
 class ExtractionTopic(SQLModel, table=True):
     __tablename__ = "extractiontopic"
     __table_args__ = (
-        Index(
-            "ix_extraction_topic_name_lower",
-            text("lower(name)"),
-            unique=True    
-        ),
+        Index("ix_extraction_topic_name_lower", text("lower(name)"), unique=True),
         {"schema": EXTRACTION_SCHEMA},
     )
-
-
 
     id: int | None = Field(default=None, primary_key=True)
     type: str
@@ -89,13 +83,12 @@ class ExtractionResult(SQLModel, table=True):
             "ix_extraction_result_title_type",
             text("lower(title)"),
             "content_type",
-            unique=True    
+            unique=True,
         ),
         {"schema": EXTRACTION_SCHEMA},
     )
 
     # CREATE UNIQUE INDEX ix_extraction_result_title_type ON extraction.extractionresult (lower(title), content_type);
-
 
     content_id: int = Field(foreign_key="content.inputcontent.id", primary_key=True)
     title: str

--- a/dsview/db/schemas/extraction_schema.py
+++ b/dsview/db/schemas/extraction_schema.py
@@ -2,6 +2,7 @@ import importlib.metadata
 import logging
 from datetime import datetime
 
+from sqlalchemy import Index, text
 from sqlmodel import ARRAY, Column, Field, Float, Relationship, SQLModel
 
 logger = logging.getLogger(__name__)
@@ -59,7 +60,16 @@ class ExtractionLink(SQLModel, table=True):
 
 class ExtractionTopic(SQLModel, table=True):
     __tablename__ = "extractiontopic"
-    __table_args__ = {"schema": EXTRACTION_SCHEMA}
+    __table_args__ = (
+        Index(
+            "ix_extraction_topic_name_lower",
+            text("lower(name)"),
+            unique=True    
+        ),
+        {"schema": EXTRACTION_SCHEMA},
+    )
+
+
 
     id: int | None = Field(default=None, primary_key=True)
     type: str
@@ -74,7 +84,18 @@ class ExtractionTopic(SQLModel, table=True):
 
 class ExtractionResult(SQLModel, table=True):
     __tablename__ = "extractionresult"
-    __table_args__ = {"schema": EXTRACTION_SCHEMA}
+    __table_args__ = (
+        Index(
+            "ix_extraction_result_title_type",
+            text("lower(title)"),
+            "content_type",
+            unique=True    
+        ),
+        {"schema": EXTRACTION_SCHEMA},
+    )
+
+    # CREATE UNIQUE INDEX ix_extraction_result_title_type ON extraction.extractionresult (lower(title), content_type);
+
 
     content_id: int = Field(foreign_key="content.inputcontent.id", primary_key=True)
     title: str

--- a/dsview/db/schemas/extraction_schema.py
+++ b/dsview/db/schemas/extraction_schema.py
@@ -35,7 +35,7 @@ class ExtractionTag(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     content_id: int = Field(
-        foreign_key=f"{EXTRACTION_SCHEMA}.extractionresult.content_id"
+        foreign_key=f"{EXTRACTION_SCHEMA}.extractionresult.content_zid"
     )
     name: str
 

--- a/dsview/extraction/content_extraction.py
+++ b/dsview/extraction/content_extraction.py
@@ -4,16 +4,9 @@ import time
 
 from sqlmodel import Session
 
-from dsview.db.ingest import (
-    embed_and_save_topic,
-    embed_and_update_topic,
-    save_er_comparison,
-    embed_and_format_extraction_results,
-)
-from dsview.db.query import TopicsIndex, get_topic_by_name
-from dsview.db.schemas import ExtractionTopic, ExtractionResult
+from dsview.db.ingest import embed_and_format_extraction_results
+from dsview.db.schemas import ExtractionResult
 from dsview.extraction.content_loader import ContentLoader, UrlLoader
-from dsview.extraction.models.er_classification import ERClassifier
 
 from .models.description_generation import (
     ContentDescription,
@@ -22,6 +15,7 @@ from .models.description_generation import (
 from .models.links_extraction import LinksExtractor, RelevantLink
 from .models.summary_generation import SummaryGenerator
 from .models.topics_extraction import DataScienceTopic, TopicsExtractor
+from .topic_er import TopicMerge, TopicResolver
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +32,7 @@ class ContentExtractor:
         self.description_generator = DescriptionGenerator()
         self.topics_extractor = TopicsExtractor()
         self.link_extractor = LinksExtractor()
-        self.er_classifier = ERClassifier()
+        self.topic_resolver = TopicResolver()
 
     async def run_extraction(
         self, content_loader: ContentLoader
@@ -71,7 +65,7 @@ class ContentExtractor:
 
     async def extract_content(
         self, content_loader: ContentLoader, session: Session, content_id: int
-    ) -> ExtractionResult:
+    ) -> tuple[ExtractionResult, list[TopicMerge]]:
         starting_time = time.perf_counter()
 
         (
@@ -80,18 +74,6 @@ class ContentExtractor:
             topics,
             content_links,
         ) = await self.run_extraction(content_loader)
-
-        # Make sure there is no duplicates in topics
-        deduped_topics = []
-        set_topic_name = set()
-
-        for topic in topics:
-            if topic.name not in set_topic_name:
-                deduped_topics.append(topic)
-                set_topic_name.add(topic.name)
-
-        if len(deduped_topics) != len(topics):
-            logger.warning("Dropped duplicates topics from LLM response !")
 
         logger.info("Saving extraction results")
 
@@ -109,96 +91,10 @@ class ContentExtractor:
 
         logger.info("Launching topic ER")
 
-        extraction_topics = await self.topics_er(deduped_topics, content_id, session)
-
-        # Failsafe deduplication
-        logger.info("Number of topics before dedup : %s", len(extraction_topics))
-
-        extraction_topics_dedup = []
-        existing_topic_ids = set()
-        for topic in extraction_topics:
-            if topic.id is not None:
-                if topic.id in existing_topic_ids:
-                    logger.warning("Found duplicate topic after ER")
-                    continue
-                existing_topic_ids.add(topic.id)
-            extraction_topics_dedup.append(topic)
-
-        logger.info("Number of topics after dedup : %s", len(extraction_topics_dedup))
-
-        extraction_result.topics = extraction_topics_dedup
+        (
+            extraction_result.topics,
+            topic_merges,
+        ) = await self.topic_resolver.resolve_topics(topics, session)
         session.add(extraction_result)
 
-        return extraction_result
-
-    async def _single_topic_er(
-        self,
-        topic: DataScienceTopic,
-        topics_index: TopicsIndex,
-        session: Session,
-    ) -> ExtractionTopic:
-        candidate_topics = topics_index.query_topic(topic)
-
-        for candidate_id, candidate_topic_dict in candidate_topics.items():
-            candidate_topic = candidate_topic_dict["topic"]
-            fts_score = candidate_topic_dict.get("fts_score")
-            vss_distance = candidate_topic_dict.get("vss_distance")
-
-            result = await self.er_classifier.async_predict(topic, candidate_topic)
-
-            save_er_comparison(
-                topic, candidate_topic, fts_score, vss_distance, result, session
-            )
-
-            if result.merge_topic:
-                # This means I don't have to update older links
-                logger.warning(
-                    "Merging topics %s and %s into %s ",
-                    topic.name,
-                    candidate_topic.name,
-                    result.topic.name,
-                )
-
-                extraction_topic = await embed_and_update_topic(
-                    candidate_id, result.topic, session
-                )
-
-                # Avoid the same candidate topic being merged multiple time
-                topics_index.delete_rows(f"id={extraction_topic.id}")
-
-                return extraction_topic
-                # return (candidate_id, candidate_topic), None
-        extraction_topic = await embed_and_save_topic(topic, session)
-
-        return extraction_topic
-
-    async def topics_er(
-        self, topics: list[DataScienceTopic], content_id: int, session: Session
-    ) -> list[ExtractionTopic]:
-        # Get topics to update
-        # update links
-        # Get new topics
-        # Update links
-        # Returns id list of updated topics and
-
-        # !!! I kinda wait topics_id to surface
-        # !! TODO Configure embedding size
-
-        existing_topics = []
-        tasks = []
-
-        with TopicsIndex() as topics_index:
-            for topic in topics:
-                existing_topic = get_topic_by_name(topic.name, session)
-
-                if existing_topic is not None:
-                    logger.warning("Topic %s already exists", topic.name)
-                    existing_topics.append(existing_topic)
-                    continue
-
-                tasks.append(self._single_topic_er(topic, topics_index, session))
-
-            # ! I am not sure but I may need thread safe session
-            extraction_topics = list(await asyncio.gather(*tasks))
-
-        return extraction_topics + existing_topics
+        return extraction_result, topic_merges

--- a/dsview/extraction/topic_er.py
+++ b/dsview/extraction/topic_er.py
@@ -1,0 +1,149 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+
+from sqlmodel import Session
+
+from dsview.db.ingest import (
+    build_er_comparison,
+    embed_and_save_topic,
+    embed_and_update_topic,
+)
+from dsview.db.query import TopicsIndex, get_topic_by_name
+from dsview.db.schemas import ERComparison, ExtractionTopic
+
+from .models.er_classification import ERClassifier
+from .models.topics_extraction import DataScienceTopic
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TopicMerge:
+    """A topic merged in place by ER: same row id, new name/type, so the vault
+    notes written under the old name are stale."""
+
+    topic_id: int
+    old_name: str
+    old_type: str
+
+
+@dataclass
+class TopicERDecision:
+    topic: DataScienceTopic
+    comparisons: list[ERComparison]
+    merge: TopicMerge | None
+
+
+def _dedup_resolved(topics: list[ExtractionTopic]) -> list[ExtractionTopic]:
+    """Failsafe: two extracted topics may resolve to the same existing row."""
+    deduped = []
+    seen_ids = set()
+
+    for topic in topics:
+        if topic.id is not None:
+            if topic.id in seen_ids:
+                logger.warning("Found duplicate topic after ER")
+                continue
+            seen_ids.add(topic.id)
+        deduped.append(topic)
+
+    logger.info("Number of topics after ER dedup : %s", len(deduped))
+
+    return deduped
+
+
+class TopicResolver:
+    def __init__(self) -> None:
+        self.er_classifier = ERClassifier()
+
+    async def _resolve_topic(
+        self, topic: DataScienceTopic, topics_index: TopicsIndex
+    ) -> TopicERDecision:
+        """Decide whether a topic merges into an existing one. Touches no session."""
+        comparisons = []
+
+        for candidate_id, candidate in topics_index.query_topic(topic).items():
+            candidate_topic = candidate["topic"]
+
+            result = await self.er_classifier.async_predict(topic, candidate_topic)
+
+            comparisons.append(
+                build_er_comparison(
+                    topic,
+                    candidate_topic,
+                    candidate["fts_score"],
+                    candidate["vss_distance"],
+                    result,
+                )
+            )
+
+            if result.merge_topic:
+                logger.warning(
+                    "Merging topics %s and %s into %s ",
+                    topic.name,
+                    candidate_topic.name,
+                    result.topic.name,
+                )
+
+                # Avoid the same candidate topic being merged multiple times
+                topics_index.delete_rows(f"id={candidate_id}")
+
+                # candidate_topic is the current DB row, i.e. the pre-merge
+                # identity the vault notes were written under
+                return TopicERDecision(
+                    result.topic,
+                    comparisons,
+                    TopicMerge(
+                        candidate_id, candidate_topic.name, candidate_topic.type.value
+                    ),
+                )
+
+        return TopicERDecision(topic, comparisons, None)
+
+    async def _apply_decision(
+        self, decision: TopicERDecision, session: Session
+    ) -> ExtractionTopic:
+        for comparison in decision.comparisons:
+            session.add(comparison)
+
+        if decision.merge is not None:
+            return await embed_and_update_topic(
+                decision.merge.topic_id, decision.topic, session
+            )
+
+        return await embed_and_save_topic(decision.topic, session)
+
+    async def resolve_topics(
+        self, topics: list[DataScienceTopic], session: Session
+    ) -> tuple[list[ExtractionTopic], list[TopicMerge]]:
+        deduped_topics = {topic.name: topic for topic in topics}
+        if len(deduped_topics) != len(topics):
+            logger.warning("Dropped duplicates topics from LLM response !")
+
+        existing_topics = []
+        tasks = []
+
+        with TopicsIndex() as topics_index:
+            for topic in deduped_topics.values():
+                existing_topic = get_topic_by_name(topic.name, session)
+
+                if existing_topic is not None:
+                    logger.warning("Topic %s already exists", topic.name)
+                    existing_topics.append(existing_topic)
+                    continue
+
+                tasks.append(self._resolve_topic(topic, topics_index))
+
+            decisions = await asyncio.gather(*tasks)
+
+        # Sequential: SQLAlchemy sessions are not safe for interleaved concurrent use.
+        extraction_topics = [
+            await self._apply_decision(decision, session) for decision in decisions
+        ]
+
+        merges = [
+            decision.merge for decision in decisions if decision.merge is not None
+        ]
+
+        return _dedup_resolved(extraction_topics + existing_topics), merges

--- a/dsview/ingest_source.py
+++ b/dsview/ingest_source.py
@@ -123,6 +123,7 @@ class IngestPipeline:
 
         session.commit()
         return error
+        
 
     def ingest_content(self, content: InputContent, session: Session):
         asyncio.run(self.async_ingest_content(content, session))

--- a/dsview/ingest_source.py
+++ b/dsview/ingest_source.py
@@ -9,14 +9,14 @@ from sqlmodel import Session
 from dsview.db.ingest import save_content, save_failed_ingestion
 from dsview.db.query import get_content
 from dsview.db.schemas import InputContent
-from dsview.db.schemas.extraction_schema import ExtractionResult, ExtractionTopic
+from dsview.db.schemas.extraction_schema import ExtractionResult
 from dsview.extraction.content_extraction import ContentExtractor
 from dsview.extraction.content_loader import (
     YOUTUBE_HOSTS,
     ContentLoader,
     get_content_loader,
 )
-from dsview.extraction.models.topics_extraction import DataScienceTopic
+from dsview.extraction.topic_er import TopicMerge
 from dsview.obsidian import write_notes
 
 logger = logging.getLogger(__name__)
@@ -65,27 +65,28 @@ class IngestPipeline:
 
     async def _extract(
         self, content_loader: ContentLoader, content_id: int, session: Session
-    ) -> ExtractionResult:
+    ) -> tuple[ExtractionResult, list[TopicMerge]]:
         logger.info("Launching content extraction")
 
-        extraction_result = await self.content_extractor.extract_content(
+        return await self.content_extractor.extract_content(
             content_loader,
             session,
             content_id,
         )
 
-        return extraction_result
-
     def _write(
         self,
         content: InputContent,
         extraction_result: ExtractionResult,
+        topic_merges: list[TopicMerge],
     ):
         logger.info("Writing extraction to Obsidian notes")
 
         # must be done before
         write_notes.write_content_note(content, extraction_result)
-        write_notes.write_and_update_topic_list_notes(extraction_result.topics)
+        write_notes.write_and_update_topic_list_notes(
+            extraction_result.topics, topic_merges
+        )
 
     async def async_ingest_content(
         self, content: InputContent, session: Session
@@ -105,11 +106,14 @@ class IngestPipeline:
         try:
             content_loader = self._load(content)
 
-            extraction_result = await self._extract(content_loader, content.id, session)
+            extraction_result, topic_merges = await self._extract(
+                content_loader, content.id, session
+            )
 
             self._write(
                 content,
                 extraction_result,
+                topic_merges,
             )
 
             logger.info("Ingestion successful.")
@@ -123,7 +127,6 @@ class IngestPipeline:
 
         session.commit()
         return error
-        
 
     def ingest_content(self, content: InputContent, session: Session):
         asyncio.run(self.async_ingest_content(content, session))

--- a/dsview/obsidian/check_vault_sync.py
+++ b/dsview/obsidian/check_vault_sync.py
@@ -209,21 +209,26 @@ def check_topic_content_relations(session: Session) -> list[Discrepancy]:
         )
     ).all()
 
-    # One entry per content: its note path, and its expected embeds keyed to their topic id.
-    info_by_content: dict[int, tuple[Path, dict[tuple[str, str], int]]] = {}
-    for content_id, title, content_type, topic_id, topic_type, topic_name in rows:
-        path = get_content_path(title, content_type)
-        _, expected = info_by_content.setdefault(content_id, (path, {}))
-        if topic_id is not None:
-            expected[(topic_type, clean_note_title(topic_name))] = topic_id
+    rows_by_content = defaultdict(list)
+    for row in rows:
+        rows_by_content[row[0]].append(row)
 
     embed_pattern = _topic_embed_pattern()
+    discrepancies = []
 
-    return [
-        d
-        for content_id, (path, expected) in info_by_content.items()
-        for d in _diff_content_relations(content_id, path, expected, embed_pattern)
-    ]
+    for content_id, content_rows in rows_by_content.items():
+        _, title, content_type, *_ = content_rows[0]
+        path = get_content_path(title, content_type)
+        expected = {
+            (topic_type, clean_note_title(topic_name)): topic_id
+            for _, _, _, topic_id, topic_type, topic_name in content_rows
+            if topic_id is not None
+        }
+        discrepancies += _diff_content_relations(
+            content_id, path, expected, embed_pattern
+        )
+
+    return discrepancies
 
 
 def check_vault_sync(session: Session) -> tuple[list[Discrepancy], dict]:

--- a/dsview/obsidian/check_vault_sync.py
+++ b/dsview/obsidian/check_vault_sync.py
@@ -1,0 +1,346 @@
+"""
+Audit topological coherence between the database (source of truth) and the
+Obsidian vault: for every content/topic row, does the note it implies exist on
+disk, does every note on disk trace back to a DB row, and does every
+content<->topic relation (extraction.contenttopicrelation) show up as the
+matching `![[topics/...]]` embed in the content note?
+
+This intentionally only tracks the shape of the note graph (nodes and the
+edges between them) - note text/frontmatter content is out of scope. Path
+collisions (two DB rows resolving to the same note path) aren't tracked here
+either - that's meant to be prevented by a DB constraint, not caught after the fact.
+"""
+
+import dataclasses
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+import regex as re
+from rich.table import Table
+from sqlmodel import Session, select
+
+from dsview.db.query import get_content_list
+from dsview.db.schemas.extraction_schema import (
+    ContentTopicRelation,
+    ExtractionResult,
+    ExtractionTopic,
+)
+
+from . import obsidian_utils
+from .obsidian_utils import (
+    clean_note_title,
+    get_content_path,
+    get_topic_path,
+    retrieve_contents_path,
+    retrieve_topics_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Discrepancy:
+    kind: str  # "content" | "topic" | "relation"
+    category: str
+    entity: str
+    content_id: int | None = None
+    topic_id: int | None = None
+    path: Path | None = None
+
+
+def _orphan_discrepancies(
+    kind: str, expected_paths: set[Path], actual_paths: set[Path]
+) -> list[Discrepancy]:
+    return [
+        Discrepancy(kind, "orphan_file", f"{path.parent.name}/{path.stem}", path=path)
+        for path in sorted(actual_paths - expected_paths)
+    ]
+
+
+def check_content_notes(session: Session) -> tuple[list[Discrepancy], int]:
+    discrepancies = []
+    expected_paths: set[Path] = set()
+    missing_extraction_count = 0
+
+    for content in get_content_list(session):
+        extraction = session.get(ExtractionResult, content.id)
+
+        if extraction is None:
+            # No note is expected until extraction has run, mirrors regen_vault.
+            missing_extraction_count += 1
+            continue
+
+        path = get_content_path(extraction.title, extraction.content_type)
+        expected_paths.add(path)
+
+        if not path.exists():
+            discrepancies.append(
+                Discrepancy(
+                    "content",
+                    "missing_note",
+                    extraction.title,
+                    content_id=content.id,
+                    path=path,
+                )
+            )
+
+    discrepancies += _orphan_discrepancies(
+        "content", expected_paths, set(retrieve_contents_path())
+    )
+
+    return discrepancies, missing_extraction_count
+
+
+def check_topic_notes(session: Session) -> list[Discrepancy]:
+    discrepancies = []
+    expected_paths: set[Path] = set()
+
+    topics = session.exec(
+        select(ExtractionTopic.id, ExtractionTopic.name, ExtractionTopic.type)
+    ).all()
+
+    for topic_id, name, type_ in topics:
+        path = get_topic_path(name, type_)
+        expected_paths.add(path)
+
+        if not path.exists():
+            discrepancies.append(
+                Discrepancy(
+                    "topic",
+                    "missing_note",
+                    f"{name} ({type_})",
+                    topic_id=topic_id,
+                    path=path,
+                )
+            )
+
+    discrepancies += _orphan_discrepancies(
+        "topic", expected_paths, set(retrieve_topics_path())
+    )
+
+    return discrepancies
+
+
+# Matches the exact embed format written by get_topic_link(): "![[<topic_dir>/<type>/<name>]]"
+def _topic_embed_pattern() -> "re.Pattern":
+    topic_dir = re.escape(obsidian_utils.config.topic_directory)
+    return re.compile(rf"!\[\[{topic_dir}/([^/\]]+)/([^\]]+)\]\]")
+
+
+def _read_topic_embeds(path: Path, pattern: "re.Pattern") -> set[tuple[str, str]]:
+    return {match.groups() for match in pattern.finditer(path.read_text())}
+
+
+def _diff_content_relations(
+    content_id: int,
+    path: Path,
+    expected: dict[tuple[str, str], int],
+    embed_pattern: "re.Pattern",
+) -> list[Discrepancy]:
+    if not path.exists():
+        return []  # already reported as content/missing_note
+
+    try:
+        actual_embeds = _read_topic_embeds(path, embed_pattern)
+    except OSError:
+        return [
+            Discrepancy(
+                "relation",
+                "unreadable_note",
+                path.stem,
+                content_id=content_id,
+                path=path,
+            )
+        ]
+
+    discrepancies = []
+
+    for embed_key in expected.keys() - actual_embeds:
+        topic_type, topic_name = embed_key
+        discrepancies.append(
+            Discrepancy(
+                "relation",
+                "missing_edge",
+                f"'{topic_name}' ({topic_type})",
+                content_id=content_id,
+                topic_id=expected[embed_key],
+                path=path,
+            )
+        )
+
+    for topic_type, topic_name in actual_embeds - expected.keys():
+        discrepancies.append(
+            Discrepancy(
+                "relation",
+                "extra_edge",
+                f"'{topic_name}' ({topic_type})",
+                content_id=content_id,
+                path=path,
+            )
+        )
+
+    return discrepancies
+
+
+def check_topic_content_relations(session: Session) -> list[Discrepancy]:
+    # Outer join so a content with zero DB relations still appears (topic=None) -
+    # its note still needs checking for embeds with no relation behind them at all.
+    # Selecting individual columns (not the full entities) skips the embedding
+    # ARRAY columns, which dominate transfer time for no benefit here.
+    rows = session.exec(
+        select(
+            ExtractionResult.content_id,
+            ExtractionResult.title,
+            ExtractionResult.content_type,
+            ExtractionTopic.id,
+            ExtractionTopic.type,
+            ExtractionTopic.name,
+        )
+        .join(
+            ContentTopicRelation,
+            ContentTopicRelation.content_id == ExtractionResult.content_id,
+            isouter=True,
+        )
+        .join(
+            ExtractionTopic,
+            ExtractionTopic.id == ContentTopicRelation.topic_id,
+            isouter=True,
+        )
+    ).all()
+
+    # One entry per content: its note path, and its expected embeds keyed to their topic id.
+    info_by_content: dict[int, tuple[Path, dict[tuple[str, str], int]]] = {}
+    for content_id, title, content_type, topic_id, topic_type, topic_name in rows:
+        path = get_content_path(title, content_type)
+        _, expected = info_by_content.setdefault(content_id, (path, {}))
+        if topic_id is not None:
+            expected[(topic_type, clean_note_title(topic_name))] = topic_id
+
+    embed_pattern = _topic_embed_pattern()
+
+    return [
+        d
+        for content_id, (path, expected) in info_by_content.items()
+        for d in _diff_content_relations(content_id, path, expected, embed_pattern)
+    ]
+
+
+def check_vault_sync(session: Session) -> tuple[list[Discrepancy], dict]:
+    content_discrepancies, missing_extraction_count = check_content_notes(session)
+    topic_discrepancies = check_topic_notes(session)
+    relation_discrepancies = check_topic_content_relations(session)
+
+    stats = {"content_missing_extraction": missing_extraction_count}
+
+    return content_discrepancies + topic_discrepancies + relation_discrepancies, stats
+
+
+CATEGORY_DESCRIPTIONS = {
+    "missing_note": "DB row has no matching file in the vault",
+    "orphan_file": "file in the vault has no matching DB row (shouldn't exist)",
+    "missing_edge": "DB content<->topic relation not reflected as a note embed",
+    "extra_edge": "note embeds a topic with no matching DB relation",
+    "unreadable_note": "file exists but could not be read",
+}
+
+KIND_ORDER = {"content": 0, "topic": 1, "relation": 2}
+
+
+def render_summary_table(discrepancies: list[Discrepancy]) -> Table:
+    table = Table(title="Vault / database topology check")
+    table.add_column("Kind", style="bold")
+    table.add_column("Category")
+    table.add_column("Count", justify="right")
+    table.add_column("Description")
+
+    by_group = defaultdict(list)
+    for d in discrepancies:
+        by_group[(d.kind, d.category)].append(d)
+
+    if not by_group:
+        table.add_row("-", "-", "0", "no discrepancies found")
+        return table
+
+    for kind, category in sorted(
+        by_group, key=lambda kc: (KIND_ORDER.get(kc[0], 9), kc[1])
+    ):
+        items = by_group[(kind, category)]
+        table.add_row(
+            kind,
+            category,
+            str(len(items)),
+            CATEGORY_DESCRIPTIONS.get(category, ""),
+        )
+
+    return table
+
+
+def render_category_table(
+    discrepancies: list[Discrepancy], kind: str, category: str
+) -> Table:
+    title = f"{kind} / {category}"
+    if description := CATEGORY_DESCRIPTIONS.get(category):
+        title += f" - {description}"
+
+    table = Table(title=title)
+    table.add_column("Entity")
+    table.add_column("Content ID", justify="right")
+    table.add_column("Topic ID", justify="right")
+    table.add_column("Path")
+
+    for d in discrepancies:
+        if d.category == category and (kind is None or d.kind == kind):
+            table.add_row(
+                d.entity,
+                str(d.content_id) if d.content_id is not None else "-",
+                str(d.topic_id) if d.topic_id is not None else "-",
+                str(d.path) if d.path is not None else "-",
+            )
+
+    return table
+
+
+def format_report(discrepancies: list[Discrepancy], stats: dict) -> str:
+    lines = []
+
+    if stats.get("content_missing_extraction"):
+        lines.append(
+            f"(info) {stats['content_missing_extraction']} content row(s) have no "
+            "extraction yet - no note is expected for them, not counted below.\n"
+        )
+
+    if not discrepancies:
+        lines.append(
+            "Vault and database are topologically in sync. No discrepancies found."
+        )
+        return "\n".join(lines)
+
+    by_group = defaultdict(list)
+    for d in discrepancies:
+        by_group[(d.kind, d.category)].append(d)
+
+    lines.append(
+        f"Found {len(discrepancies)} discrepancies across {len(by_group)} (kind, category) groups:\n"
+    )
+
+    for (kind, category), items in sorted(
+        by_group.items(), key=lambda kc: (KIND_ORDER.get(kc[0][0], 9), kc[0][1])
+    ):
+        description = CATEGORY_DESCRIPTIONS.get(category, "")
+        lines.append(f"## {kind} / {category} ({len(items)}) - {description}")
+        for d in items:
+            ids = [
+                f"{name}={value}"
+                for name, value in (
+                    ("content_id", d.content_id),
+                    ("topic_id", d.topic_id),
+                    ("path", d.path),
+                )
+                if value is not None
+            ]
+            id_str = f" [{', '.join(ids)}]" if ids else ""
+            lines.append(f"- {d.entity}{id_str}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/dsview/obsidian/write_notes.py
+++ b/dsview/obsidian/write_notes.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import frontmatter
-from sqlmodel import inspect
 
 from dsview.db.schemas import (
     ExtractionTopic,
@@ -11,6 +13,11 @@ from dsview.db.schemas import (
 from dsview.db.schemas.extraction_schema import ExtractionResult
 
 from .obsidian_utils import get_content_path, get_topic_link, get_topic_path
+
+if TYPE_CHECKING:
+    # Imported here: topic_er pulls in the extraction models, whose enums are
+    # built from config at import time, and cli.py imports this module
+    from dsview.extraction.topic_er import TopicMerge
 
 logger = logging.getLogger(__name__)
 
@@ -44,52 +51,61 @@ def write_topic_note(topic: ExtractionTopic):
     write_note(note, topic_path)
 
 
-def update_topic_note(topic: ExtractionTopic):
-    topic_inspection = inspect(topic)
+def update_topic_note(topic: ExtractionTopic, old_name: str, old_type: str):
+    """Rewrite the vault after a merge renamed `topic` from (old_name, old_type).
 
-    old_topic_name = topic_inspection.attrs.name.history.non_added()[0]
-    old_topic_type = topic_inspection.attrs.type.history.non_added()[0]
+    The pre-merge identity is passed in rather than read back from the SQLAlchemy
+    attribute history, which any flush resets (see #55).
+    """
+    logger.warning("Updating topic note %s to %s", old_name, topic.name)
 
-    logger.warning("Updating topic note %s to %s", old_topic_name, topic.name)
+    # Deleting old note. A merge often keeps the name and type, in which case
+    # this is the note write_topic_note is about to write again
+    old_topic_path = get_topic_path(old_name, old_type)
 
-    # Deleting old note
-    old_topic_path = get_topic_path(
-        old_topic_name,
-        old_topic_type,
-    )
     if old_topic_path.exists():
         old_topic_path.unlink()
     else:
-        logger.error(
-            "Could not find topic note : %s. Continuing anyway", old_topic_name
-        )
+        logger.error("Could not find topic note : %s. Continuing anyway", old_name)
 
     write_topic_note(topic)
 
-    # Writing updated note
-    old_topic_link = get_topic_link(old_topic_name, old_topic_type)
+    old_topic_link = get_topic_link(old_name, old_type)
     new_topic_link = get_topic_link(topic.name, topic.type)
 
     for extraction in topic.extractions:
         content_path = get_content_path(extraction.title, extraction.content_type)
+
+        if not content_path.exists():
+            logger.error(
+                "Could not find content note : %s. Continuing anyway", extraction.title
+            )
+            continue
+
         content_note = frontmatter.load(content_path)
 
+        # Matching the bare link: frontmatter strips trailing newlines, so the
+        # last embed of a note has no "\n\n" after it
         content_note.content = content_note.content.replace(
-            f"{old_topic_link}\n\n",
-            f"{new_topic_link}\n\n",
+            old_topic_link,
+            new_topic_link,
         )
 
         write_note(content_note, content_path)
 
 
-def write_and_update_topic_list_notes(topics: list[ExtractionTopic]):
-    for topic in topics:
-        topic_inspection = inspect(topic)
+def write_and_update_topic_list_notes(
+    topics: list[ExtractionTopic], merges: list[TopicMerge]
+):
+    merged_topics = {merge.topic_id: merge for merge in merges}
 
-        if topic_inspection.modified and topic_inspection.has_identity:
-            update_topic_note(topic)
-        else:
+    for topic in topics:
+        merge = merged_topics.get(topic.id)
+
+        if merge is None:
             write_topic_note(topic)
+        else:
+            update_topic_note(topic, merge.old_name, merge.old_type)
 
 
 # ? What about jinja template for this

--- a/install_env.sh
+++ b/install_env.sh
@@ -1,10 +1,14 @@
 
 curl -fsSL https://claude.ai/install.sh | bash
-
-
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 sudo apt-get update
 sudo apt-get install zstd
 curl -fsSL https://ollama.com/install.sh | sh
+
+ollama serve &
+
 ollama pull smollm2:1.7b
 ollama pull all-minilm:latest
+
+uv sync --group api

--- a/notebooks/explore_duplicates.py
+++ b/notebooks/explore_duplicates.py
@@ -1,0 +1,143 @@
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    from dsview.db import get_engine
+
+    return get_engine, mo
+
+
+@app.cell
+def _(get_engine):
+    engine = get_engine()
+    return (engine,)
+
+
+@app.cell(hide_code=True)
+def _(engine, mo):
+    extraction_results = mo.sql(
+        f"""
+        SELECT * FROM extraction.extractionresult
+        """,
+        engine=engine
+    )
+    return (extraction_results,)
+
+
+@app.cell
+def _(extraction_results):
+    extraction_results["title"].nunique()
+    return
+
+
+@app.cell
+def _(extraction_results):
+    extraction_results["title_lower"] = extraction_results["title"].str.lower()
+    return
+
+
+@app.cell
+def _(extraction_results):
+    extraction_results[extraction_results.duplicated(subset=["title_lower"], keep=False)]
+    return
+
+
+@app.cell
+def _(extraction_results):
+    extraction_results[extraction_results.duplicated(subset=["title"], keep=False)]
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell(hide_code=True)
+def _(engine, mo):
+    extraction_topics = mo.sql(
+        f"""
+        SELECT * FROM extraction.extractiontopic
+        """,
+        engine=engine
+    )
+    return (extraction_topics,)
+
+
+@app.cell
+def _(extraction_topics):
+    extraction_topics["name"].nunique()
+    return
+
+
+@app.cell
+def _(extraction_topics):
+    extraction_topics["name_lower"] = extraction_topics["name"].str.lower()
+    return
+
+
+@app.cell
+def _(extraction_topics):
+    extraction_topics[extraction_topics.duplicated(subset=["name_lower"], keep=False)]
+    return
+
+
+@app.cell
+def _(extraction_topics):
+    extraction_topics[extraction_topics["name_lower"].str.startswith("in-context")]
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    update date > Max date linked contents
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(engine, mo):
+    _df = mo.sql(
+        f"""
+        SELECT
+            *
+        FROM
+            extraction.contenttopicrelation t1
+        JOIN
+            content.inputcontent t2
+        on t1.content_id=t2.id
+        WHERE
+            topic_id = 1198
+        LIMIT
+            100
+        """,
+        engine=engine
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(engine, mo):
+    _df = mo.sql(
+        f"""
+        SELECT * FROM content.failedingestion
+        """,
+        engine=engine
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/explore_duplicates.py
+++ b/notebooks/explore_duplicates.py
@@ -58,7 +58,7 @@ def _(extraction_results):
 def _(engine, mo):
     _df = mo.sql(
         f"""
-        SELECT * FROM content.inputcontent WHERE id IN (307, 543)
+        SELECT * FROM content.inputcontent WHERE id IN (643, 744, 745)
         """,
         engine=engine
     )
@@ -105,6 +105,12 @@ def _(mo):
     mo.md(r"""
     update date > Max date linked contents
     """)
+    return
+
+
+@app.cell
+def _():
+    708 > 740
     return
 
 

--- a/notebooks/explore_duplicates.py
+++ b/notebooks/explore_duplicates.py
@@ -54,8 +54,14 @@ def _(extraction_results):
     return
 
 
-@app.cell
-def _():
+@app.cell(hide_code=True)
+def _(engine, mo):
+    _df = mo.sql(
+        f"""
+        SELECT * FROM content.inputcontent WHERE id IN (307, 543)
+        """,
+        engine=engine
+    )
     return
 
 

--- a/scripts/delete_content.py
+++ b/scripts/delete_content.py
@@ -1,0 +1,40 @@
+"""Delete all rows for a given content_id across the content and extraction schemas."""
+
+import argparse
+import logging
+
+from sqlmodel import Session, text
+
+from dsview.db import engine
+
+logger = logging.getLogger(__name__)
+
+# Order matters: children of extractionresult first, then extractionresult,
+# then failedingestion, then inputcontent last (everything FKs to it).
+# extractiontopic is untouched: topics are shared across contents.
+DELETE_STATEMENTS = [
+    "DELETE FROM extraction.extractiontag WHERE content_id = :content_id",
+    "DELETE FROM extraction.extractionlink WHERE content_id = :content_id",
+    "DELETE FROM extraction.contenttopicrelation WHERE content_id = :content_id",
+    "DELETE FROM extraction.extractionresult WHERE content_id = :content_id",
+    "DELETE FROM content.failedingestion WHERE content_id = :content_id",
+    "DELETE FROM content.inputcontent WHERE id = :content_id",
+]
+
+
+def delete_content(content_id: int) -> None:
+    with Session(engine) as session:
+        for statement in DELETE_STATEMENTS:
+            result = session.exec(text(statement), params={"content_id": content_id})
+            logger.info("%s -> %d row(s)", statement, result.rowcount)
+        session.commit()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("content_id", type=int)
+    args = parser.parse_args()
+
+    delete_content(args.content_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import pytest
+from sqlalchemy import ARRAY, event
+from sqlalchemy.ext.compiler import compiles
+from sqlmodel import Session, SQLModel, create_engine
+
+import dsview.db.schemas  # noqa: F401  registers every table on SQLModel.metadata
+from dsview.config import ObsidianConfig
+from dsview.obsidian import obsidian_utils
+
+POSTGRES_SCHEMAS = ("content", "extraction", "labels")
+
+
+# Embedding columns are Postgres ARRAY(Float) and SQLite has no array binding,
+# so the DDL just needs a renderable type; tests insert a NULL embedding.
+@compiles(ARRAY, "sqlite")
+def _compile_array_sqlite(element, compiler, **kw):
+    return "JSON"
+
+
+@pytest.fixture
+def session():
+    """Throwaway in-memory database with the full schema, for hermetic DB tests."""
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def attach_schemas(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        for schema in POSTGRES_SCHEMAS:
+            cursor.execute(f"ATTACH DATABASE ':memory:' AS {schema}")
+        cursor.close()
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    """Throwaway Obsidian vault, for hermetic note-writing tests."""
+    vault_path = tmp_path / "vault"
+    (vault_path / "contents").mkdir(parents=True)
+    (vault_path / "topics").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        obsidian_utils,
+        "config",
+        ObsidianConfig(
+            vault_path=vault_path,
+            content_directory="contents",
+            topic_directory="topics",
+        ),
+    )
+    return vault_path

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,158 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import typer
+
+from dsview import cli
+from dsview.obsidian.sync_vault import CommandFailed
+
+
+@dataclass
+class FakePostgresConfig:
+    host: str = "localhost"
+    port: int = 5432
+    database: str = "test_db"
+    user: str = "test_user"
+    password: str = "test_password"
+
+
+@pytest.fixture
+def fake_pg_config(monkeypatch):
+    monkeypatch.setattr(cli, "load_postgres_config", lambda: FakePostgresConfig())
+
+
+@pytest.fixture
+def fake_pg_tools(monkeypatch):
+    monkeypatch.setattr(
+        cli.shutil,
+        "which",
+        lambda tool: f"/usr/bin/{tool}" if tool.startswith("pg_") else None,
+    )
+
+
+@pytest.fixture
+def captured_run_cmd(monkeypatch):
+    calls = []
+
+    def fake_run_cmd(cmd, label, **kwargs):
+        calls.append((cmd, label, kwargs))
+
+    monkeypatch.setattr(cli, "run_cmd", fake_run_cmd)
+    return calls
+
+
+def test_backup_invokes_pg_dump_with_timestamped_output(
+    tmp_path, monkeypatch, fake_pg_config, fake_pg_tools, captured_run_cmd
+):
+    monkeypatch.chdir(tmp_path)
+
+    cli.backup()
+
+    assert len(captured_run_cmd) == 1
+    cmd, label, kwargs = captured_run_cmd[0]
+
+    assert label == "pg_dump backup"
+    assert cmd[0] == "/usr/bin/pg_dump"
+    assert "-Fc" in cmd
+    assert "--no-owner" in cmd
+    assert "--no-privileges" in cmd
+    assert cmd[cmd.index("-h") + 1] == "localhost"
+    assert cmd[cmd.index("-p") + 1] == "5432"
+    assert cmd[cmd.index("-U") + 1] == "test_user"
+    assert cmd[cmd.index("-d") + 1] == "test_db"
+
+    output_file = Path(cmd[cmd.index("-f") + 1])
+    assert output_file.resolve().parent == tmp_path / "backup"
+    assert output_file.resolve().parent.exists()
+    assert output_file.name.startswith("dsview_")
+    assert output_file.suffix == ".dump"
+
+    assert "test_password" not in cmd
+    assert kwargs["env"]["PGPASSWORD"] == "test_password"
+
+
+def test_backup_raises_when_pg_dump_missing(
+    tmp_path, monkeypatch, fake_pg_config, captured_run_cmd
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli.shutil, "which", lambda tool: None)
+
+    with pytest.raises(cli.MissingPostgresTool):
+        cli.backup()
+
+    assert captured_run_cmd == []
+
+
+def test_backup_propagates_command_failure(
+    tmp_path, monkeypatch, fake_pg_config, fake_pg_tools
+):
+    monkeypatch.chdir(tmp_path)
+
+    def failing_run_cmd(cmd, label, **kwargs):
+        raise CommandFailed(label, "", "pg_dump: error")
+
+    monkeypatch.setattr(cli, "run_cmd", failing_run_cmd)
+
+    with pytest.raises(CommandFailed):
+        cli.backup()
+
+
+def test_restore_db_picks_newest_dump_and_confirms(
+    tmp_path, monkeypatch, fake_pg_config, fake_pg_tools, captured_run_cmd
+):
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+
+    older = backup_dir / "dsview_20260101_000000.dump"
+    newer = backup_dir / "dsview_20260810_000000.dump"
+    older.write_bytes(b"old")
+    newer.write_bytes(b"new")
+
+    now = 1_700_000_000
+    os.utime(older, (now, now))
+    os.utime(newer, (now + 100, now + 100))
+
+    monkeypatch.setattr(typer, "confirm", lambda *a, **k: True)
+
+    cli.restore_db(backup_file=None, backup_dir=str(backup_dir))
+
+    assert len(captured_run_cmd) == 1
+    cmd, label, kwargs = captured_run_cmd[0]
+
+    assert label == "pg_restore restore"
+    assert cmd[0] == "/usr/bin/pg_restore"
+    assert "--clean" in cmd
+    assert "--if-exists" in cmd
+    assert str(newer) in cmd
+    assert str(older) not in cmd
+    assert kwargs["env"]["PGPASSWORD"] == "test_password"
+
+
+def test_restore_db_aborts_when_not_confirmed(
+    tmp_path, monkeypatch, fake_pg_config, fake_pg_tools, captured_run_cmd
+):
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+    (backup_dir / "dsview_20260810_000000.dump").write_bytes(b"data")
+
+    monkeypatch.setattr(typer, "confirm", lambda *a, **k: False)
+
+    with pytest.raises(typer.Abort):
+        cli.restore_db(backup_file=None, backup_dir=str(backup_dir))
+
+    assert captured_run_cmd == []
+
+
+def test_restore_db_raises_when_no_dump_files(tmp_path, fake_pg_config):
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+
+    with pytest.raises(cli.NoBackupFileFound):
+        cli.restore_db(backup_file=None, backup_dir=str(backup_dir))
+
+
+def test_restore_db_raises_when_backup_dir_missing(tmp_path, fake_pg_config):
+    with pytest.raises(cli.MissingBackupDirectory):
+        cli.restore_db(backup_file=None, backup_dir=str(tmp_path / "does_not_exist"))

--- a/tests/test_check_vault_sync.py
+++ b/tests/test_check_vault_sync.py
@@ -1,18 +1,10 @@
 from datetime import date, datetime
 
-import pytest
-from sqlalchemy import ARRAY, event, text
-from sqlalchemy.ext.compiler import compiles
-from sqlmodel import Session, SQLModel, create_engine
+from sqlalchemy import text
+from sqlmodel import Session
 
-from dsview.config import ObsidianConfig
 from dsview.db.schemas import InputContent
-from dsview.db.schemas.extraction_schema import (
-    ContentTopicRelation,
-    ExtractionResult,
-    ExtractionTopic,
-)
-from dsview.obsidian import obsidian_utils
+from dsview.db.schemas.extraction_schema import ContentTopicRelation
 from dsview.obsidian.check_vault_sync import (
     check_content_notes,
     check_topic_content_relations,
@@ -27,57 +19,6 @@ from dsview.obsidian.obsidian_utils import (
     get_topic_link,
     get_topic_path,
 )
-
-
-# ExtractionResult/ExtractionTopic.embedding is a Postgres ARRAY(Float) column;
-# SQLite has no array binding, but check_vault_sync never reads .embedding, so
-# DDL just needs a renderable type and rows are inserted with a NULL embedding.
-@compiles(ARRAY, "sqlite")
-def _compile_array_sqlite(element, compiler, **kw):
-    return "JSON"
-
-
-@pytest.fixture
-def session():
-    engine = create_engine("sqlite:///:memory:")
-
-    @event.listens_for(engine, "connect")
-    def attach_schemas(dbapi_connection, connection_record):
-        cursor = dbapi_connection.cursor()
-        cursor.execute("ATTACH DATABASE ':memory:' AS content")
-        cursor.execute("ATTACH DATABASE ':memory:' AS extraction")
-        cursor.close()
-
-    SQLModel.metadata.create_all(
-        engine,
-        tables=[
-            InputContent.__table__,
-            ExtractionResult.__table__,
-            ExtractionTopic.__table__,
-            ContentTopicRelation.__table__,
-        ],
-    )
-
-    with Session(engine) as session:
-        yield session
-
-
-@pytest.fixture
-def vault(tmp_path, monkeypatch):
-    vault_path = tmp_path / "vault"
-    (vault_path / "contents").mkdir(parents=True)
-    (vault_path / "topics").mkdir(parents=True)
-
-    monkeypatch.setattr(
-        obsidian_utils,
-        "config",
-        ObsidianConfig(
-            vault_path=vault_path,
-            content_directory="contents",
-            topic_directory="topics",
-        ),
-    )
-    return vault_path
 
 
 def _add_content(session: Session, link: str) -> InputContent:

--- a/tests/test_check_vault_sync.py
+++ b/tests/test_check_vault_sync.py
@@ -1,0 +1,376 @@
+from datetime import date, datetime
+
+import pytest
+from sqlalchemy import ARRAY, event, text
+from sqlalchemy.ext.compiler import compiles
+from sqlmodel import Session, SQLModel, create_engine
+
+from dsview.config import ObsidianConfig
+from dsview.db.schemas import InputContent
+from dsview.db.schemas.extraction_schema import (
+    ContentTopicRelation,
+    ExtractionResult,
+    ExtractionTopic,
+)
+from dsview.obsidian import obsidian_utils
+from dsview.obsidian.check_vault_sync import (
+    check_content_notes,
+    check_topic_content_relations,
+    check_topic_notes,
+    check_vault_sync,
+    format_report,
+    render_category_table,
+    render_summary_table,
+)
+from dsview.obsidian.obsidian_utils import (
+    get_content_path,
+    get_topic_link,
+    get_topic_path,
+)
+
+
+# ExtractionResult/ExtractionTopic.embedding is a Postgres ARRAY(Float) column;
+# SQLite has no array binding, but check_vault_sync never reads .embedding, so
+# DDL just needs a renderable type and rows are inserted with a NULL embedding.
+@compiles(ARRAY, "sqlite")
+def _compile_array_sqlite(element, compiler, **kw):
+    return "JSON"
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def attach_schemas(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("ATTACH DATABASE ':memory:' AS content")
+        cursor.execute("ATTACH DATABASE ':memory:' AS extraction")
+        cursor.close()
+
+    SQLModel.metadata.create_all(
+        engine,
+        tables=[
+            InputContent.__table__,
+            ExtractionResult.__table__,
+            ExtractionTopic.__table__,
+            ContentTopicRelation.__table__,
+        ],
+    )
+
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    vault_path = tmp_path / "vault"
+    (vault_path / "contents").mkdir(parents=True)
+    (vault_path / "topics").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        obsidian_utils,
+        "config",
+        ObsidianConfig(
+            vault_path=vault_path,
+            content_directory="contents",
+            topic_directory="topics",
+        ),
+    )
+    return vault_path
+
+
+def _add_content(session: Session, link: str) -> InputContent:
+    content = InputContent(link=link, upload_date=date.today())
+    session.add(content)
+    session.commit()
+    session.refresh(content)
+    return content
+
+
+def _add_extraction(session: Session, content_id: int, title: str, content_type: str):
+    session.exec(
+        text(
+            "INSERT INTO extraction.extractionresult "
+            "(content_id, title, content_type, summary, embedding, extraction_time) "
+            "VALUES (:content_id, :title, :content_type, 'summary', NULL, :extraction_time)"
+        ),
+        params={
+            "content_id": content_id,
+            "title": title,
+            "content_type": content_type,
+            "extraction_time": datetime.now().isoformat(),
+        },
+    )
+    session.commit()
+
+
+def _add_topic(
+    session: Session, name: str, type_: str, description: str = "desc"
+) -> int:
+    session.exec(
+        text(
+            "INSERT INTO extraction.extractiontopic (type, name, description, embedding) "
+            "VALUES (:type, :name, :description, NULL)"
+        ),
+        params={"type": type_, "name": name, "description": description},
+    )
+    session.commit()
+    return session.exec(
+        text("SELECT id FROM extraction.extractiontopic WHERE name = :name"),
+        params={"name": name},
+    ).one()[0]
+
+
+def _add_relation(session: Session, content_id: int, topic_id: int):
+    session.add(ContentTopicRelation(content_id=content_id, topic_id=topic_id))
+    session.commit()
+
+
+def _write_note(path, body: str = "note body"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+# --- check_content_notes -----------------------------------------------------
+
+
+def test_content_note_present_produces_no_discrepancy(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    _write_note(get_content_path("Title A", "Blog post"))
+
+    discrepancies, missing_extraction_count = check_content_notes(session)
+
+    assert discrepancies == []
+    assert missing_extraction_count == 0
+
+
+def test_content_without_note_is_missing(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+
+    discrepancies, _ = check_content_notes(session)
+
+    assert len(discrepancies) == 1
+    d = discrepancies[0]
+    assert d.kind == "content"
+    assert d.category == "missing_note"
+    assert d.content_id == content.id
+    assert d.entity == "Title A"
+    assert d.path == get_content_path("Title A", "Blog post")
+
+
+def test_content_without_extraction_is_skipped_not_flagged(session, vault):
+    _add_content(session, "https://example.com/a")
+
+    discrepancies, missing_extraction_count = check_content_notes(session)
+
+    assert discrepancies == []
+    assert missing_extraction_count == 1
+
+
+# --- check_topic_notes --------------------------------------------------------
+
+
+def test_topic_note_present_produces_no_discrepancy(session, vault):
+    _add_topic(session, "LLM", "Concept")
+    _write_note(get_topic_path("LLM", "Concept"))
+
+    discrepancies = check_topic_notes(session)
+
+    assert discrepancies == []
+
+
+def test_topic_without_note_is_missing(session, vault):
+    topic_id = _add_topic(session, "LLM", "Concept")
+
+    discrepancies = check_topic_notes(session)
+
+    assert len(discrepancies) == 1
+    assert discrepancies[0].kind == "topic"
+    assert discrepancies[0].category == "missing_note"
+    assert discrepancies[0].topic_id == topic_id
+    assert discrepancies[0].entity == "LLM (Concept)"
+    assert discrepancies[0].path == get_topic_path("LLM", "Concept")
+
+
+def test_orphan_topic_file_is_flagged(session, vault):
+    # Simulates a topic renamed/merged in the DB whose old note was never removed.
+    _write_note(get_topic_path("Old Name", "Concept"))
+
+    discrepancies = check_topic_notes(session)
+
+    assert len(discrepancies) == 1
+    assert discrepancies[0].kind == "topic"
+    assert discrepancies[0].category == "orphan_file"
+    assert discrepancies[0].content_id is None
+    assert discrepancies[0].topic_id is None
+    assert discrepancies[0].entity == "Concept/Old Name"
+    assert discrepancies[0].path == get_topic_path("Old Name", "Concept")
+
+
+# --- check_topic_content_relations -------------------------------------------
+
+
+def test_matching_relation_and_embed_produce_no_discrepancy(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    topic_id = _add_topic(session, "LLM", "Concept")
+    _add_relation(session, content.id, topic_id)
+    _write_note(
+        get_content_path("Title A", "Blog post"),
+        body=f"body\n\n## Topics\n\n{get_topic_link('LLM', 'Concept')}\n\n",
+    )
+
+    discrepancies = check_topic_content_relations(session)
+
+    assert discrepancies == []
+
+
+def test_relation_without_embed_is_missing_edge(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    topic_id = _add_topic(session, "LLM", "Concept")
+    _add_relation(session, content.id, topic_id)
+    _write_note(
+        get_content_path("Title A", "Blog post"), body="body with no topic embeds"
+    )
+
+    discrepancies = check_topic_content_relations(session)
+
+    assert len(discrepancies) == 1
+    assert discrepancies[0].kind == "relation"
+    assert discrepancies[0].category == "missing_edge"
+    assert discrepancies[0].entity == "'LLM' (Concept)"
+    assert discrepancies[0].content_id == content.id
+    assert discrepancies[0].topic_id == topic_id
+    assert discrepancies[0].path == get_content_path("Title A", "Blog post")
+
+
+def test_embed_without_relation_is_extra_edge(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    _add_topic(session, "LLM", "Concept")
+    # Topic exists in the DB, but no relation row: the note still embeds it anyway.
+    _write_note(
+        get_content_path("Title A", "Blog post"),
+        body=f"body\n\n## Topics\n\n{get_topic_link('LLM', 'Concept')}\n\n",
+    )
+
+    discrepancies = check_topic_content_relations(session)
+
+    assert len(discrepancies) == 1
+    assert discrepancies[0].category == "extra_edge"
+    assert discrepancies[0].entity == "'LLM' (Concept)"
+    assert discrepancies[0].content_id == content.id
+    # extra_edge deliberately doesn't resolve against the topics table (see prior review).
+    assert discrepancies[0].topic_id is None
+
+
+def test_content_with_zero_relations_reports_extra_edge_for_stray_embed(session, vault):
+    # Regression guard for the outer join: a content with no contenttopicrelation
+    # rows at all must still be checked, not silently dropped from the query.
+    # The embedded topic doesn't even exist in the DB (e.g. merged away) - extra_edge
+    # reporting must not depend on resolving it against the topics table.
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    _write_note(
+        get_content_path("Title A", "Blog post"),
+        body="body\n\n## Topics\n\n![[topics/Concept/Gone Topic]]\n\n",
+    )
+
+    discrepancies = check_topic_content_relations(session)
+
+    assert len(discrepancies) == 1
+    assert discrepancies[0].category == "extra_edge"
+    assert discrepancies[0].entity == "'Gone Topic' (Concept)"
+    assert discrepancies[0].content_id == content.id
+    assert discrepancies[0].topic_id is None
+
+
+def test_relation_skipped_when_content_note_missing(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    topic_id = _add_topic(session, "LLM", "Concept")
+    _add_relation(session, content.id, topic_id)
+    # No note written for the content at all.
+
+    discrepancies = check_topic_content_relations(session)
+
+    # Already reported as content/missing_note; must not also surface as a relation issue.
+    assert discrepancies == []
+
+
+# --- check_vault_sync (integration) ------------------------------------------
+
+
+def test_check_vault_sync_aggregates_all_discrepancy_kinds(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    # Content note left unwritten -> content/missing_note.
+
+    _add_content(session, "https://example.com/b")
+    # No extraction -> counted in stats, not a discrepancy.
+
+    _write_note(get_topic_path("Orphan", "Concept"))
+    # No matching DB topic -> topic/orphan_file.
+
+    discrepancies, stats = check_vault_sync(session)
+
+    assert stats == {"content_missing_extraction": 1}
+    categories = {(d.kind, d.category) for d in discrepancies}
+    assert ("content", "missing_note") in categories
+    assert ("topic", "orphan_file") in categories
+
+
+def test_check_vault_sync_clean_state_has_no_discrepancies(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    topic_id = _add_topic(session, "LLM", "Concept")
+    _add_relation(session, content.id, topic_id)
+    _write_note(get_topic_path("LLM", "Concept"))
+    _write_note(
+        get_content_path("Title A", "Blog post"),
+        body=f"body\n\n## Topics\n\n{get_topic_link('LLM', 'Concept')}\n\n",
+    )
+
+    discrepancies, stats = check_vault_sync(session)
+
+    assert discrepancies == []
+    assert stats == {"content_missing_extraction": 0}
+
+
+# --- rendering / formatting ---------------------------------------------------
+
+
+def test_render_summary_table_empty():
+    table = render_summary_table([])
+
+    assert table.row_count == 1  # the "no discrepancies found" placeholder row
+
+
+def test_render_category_table_filters_by_kind_and_category(session, vault):
+    content = _add_content(session, "https://example.com/a")
+    _add_extraction(session, content.id, "Title A", "Blog post")
+    discrepancies, _ = check_content_notes(session)
+
+    table = render_category_table(discrepancies, "content", "missing_note")
+
+    assert table.row_count == 1
+
+
+def test_format_report_no_discrepancies():
+    report = format_report([], {"content_missing_extraction": 0})
+
+    assert "fully" in report.lower() or "no discrepancies" in report.lower()
+
+
+def test_format_report_lists_each_group(session, vault):
+    _write_note(get_topic_path("Orphan", "Concept"))
+    discrepancies, stats = check_vault_sync(session)
+
+    report = format_report(discrepancies, stats)
+
+    assert "topic / orphan_file (1)" in report
+    assert "Orphan" in report

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,29 +1,9 @@
 from datetime import date
 
-import pytest
-from sqlalchemy import event
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session
 
 from dsview.db.query import get_failed_ingestion
 from dsview.db.schemas import FailedIngestion, InputContent
-
-
-@pytest.fixture
-def session():
-    engine = create_engine("sqlite:///:memory:")
-
-    @event.listens_for(engine, "connect")
-    def attach_content_schema(dbapi_connection, connection_record):
-        cursor = dbapi_connection.cursor()
-        cursor.execute("ATTACH DATABASE ':memory:' AS content")
-        cursor.close()
-
-    SQLModel.metadata.create_all(
-        engine, tables=[InputContent.__table__, FailedIngestion.__table__]
-    )
-
-    with Session(engine) as session:
-        yield session
 
 
 def _saved_content(session: Session) -> InputContent:

--- a/tests/test_topic_er.py
+++ b/tests/test_topic_er.py
@@ -1,0 +1,279 @@
+import asyncio
+
+import pytest
+from sqlalchemy import select
+from sqlmodel import Session
+
+from dsview.db.ingest import ingest_extraction
+from dsview.db.schemas.extraction_schema import ERComparison, ExtractionTopic
+from dsview.extraction import topic_er
+from dsview.extraction.models.er_classification import ERResult
+from dsview.extraction.models.topics_extraction import DataScienceTopic, TopicType
+from dsview.extraction.topic_er import TopicERDecision, TopicMerge, TopicResolver
+
+
+@pytest.fixture
+def embedder(monkeypatch):
+    """Replace the lazy INDEX model provider used by embed_and_{save,update}_topic."""
+
+    class StubProvider:
+        def __init__(self):
+            self.embedded = []
+
+        async def async_embed(self, text: str):
+            # None, not a vector: SQLite cannot bind the Postgres ARRAY column
+            self.embedded.append(text)
+
+    stub = StubProvider()
+    monkeypatch.setattr(ingest_extraction, "model_provider", stub)
+
+    return stub
+
+
+def make_topic(name: str, topic_type: TopicType = TopicType.CONCEPT):
+    return DataScienceTopic(
+        name=name, type=topic_type, description=f"description of {name}"
+    )
+
+
+def make_resolver(monkeypatch, results: list[ERResult]) -> TopicResolver:
+    """A TopicResolver whose classifier replays `results`, one per comparison."""
+
+    class StubClassifier:
+        def __init__(self):
+            self.calls = []
+
+        async def async_predict(self, topic1, topic2):
+            self.calls.append((topic1.name, topic2.name))
+            return results[len(self.calls) - 1]
+
+    monkeypatch.setattr(topic_er, "ERClassifier", StubClassifier)
+
+    return TopicResolver()
+
+
+class StubTopicsIndex:
+    """Stands in for the DuckDB-backed TopicsIndex (candidates keyed by topic id)."""
+
+    def __init__(self, candidates: dict[str, dict[int, DataScienceTopic]]):
+        self.candidates = candidates
+        self.deleted = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def query_topic(self, topic):
+        return {
+            candidate_id: {
+                "topic": candidate,
+                "fts_score": 1.0,
+                "vss_distance": 0.1,
+            }
+            for candidate_id, candidate in self.candidates.get(topic.name, {}).items()
+        }
+
+    def delete_rows(self, where_clause):
+        self.deleted.append(where_clause)
+
+
+def merge_result(topic: DataScienceTopic) -> ERResult:
+    return ERResult(analysis="same thing", merge_topic=True, topic=topic)
+
+
+def no_merge_result() -> ERResult:
+    return ERResult(analysis="different", merge_topic=False, topic=None)
+
+
+def seed_topic(session: Session, name: str, topic_type: TopicType) -> int:
+    """Insert a topic and detach it, so it is not in the session identity map."""
+    topic = ExtractionTopic(
+        name=name, type=topic_type.value, description=f"description of {name}"
+    )
+    session.add(topic)
+    session.commit()
+    topic_id = topic.id
+    session.expunge_all()
+
+    return topic_id
+
+
+# --- _resolve_topic: async decision phase, no session ------------------------
+
+
+def test_resolve_topic_without_candidates_is_an_insert(monkeypatch):
+    resolver = make_resolver(monkeypatch, [])
+    topic = make_topic("Diffusion Models")
+
+    decision = asyncio.run(resolver._resolve_topic(topic, StubTopicsIndex({})))
+
+    assert decision == TopicERDecision(topic, [], None)
+
+
+def test_resolve_topic_stops_at_the_first_merging_candidate(monkeypatch):
+    topic = make_topic("BigQuery")
+    merged = make_topic("Google BigQuery", TopicType.TOOL)
+    index = StubTopicsIndex(
+        {
+            "BigQuery": {
+                11: make_topic("Big Query Studio", TopicType.TOOL),
+                12: make_topic("Google BigQuery", TopicType.PLATFORM),
+                13: make_topic("Never Examined"),
+            }
+        }
+    )
+    resolver = make_resolver(
+        monkeypatch, [no_merge_result(), merge_result(merged), no_merge_result()]
+    )
+
+    decision = asyncio.run(resolver._resolve_topic(topic, index))
+
+    # the pre-merge identity of candidate 12, not the merged one
+    assert decision.merge == TopicMerge(12, "Google BigQuery", "Platform")
+    assert decision.topic == merged
+    # third candidate is never examined
+    assert resolver.er_classifier.calls == [
+        ("BigQuery", "Big Query Studio"),
+        ("BigQuery", "Google BigQuery"),
+    ]
+    assert [comparison.name_2 for comparison in decision.comparisons] == [
+        "Big Query Studio",
+        "Google BigQuery",
+    ]
+    assert [comparison.merge_topic for comparison in decision.comparisons] == [
+        False,
+        True,
+    ]
+    # the merged candidate must not be offered to a later topic of the same batch
+    assert index.deleted == ["id=12"]
+
+
+# --- _apply_decision: sequential session phase -------------------------------
+
+
+def test_apply_decision_inserts_new_topic_and_comparisons(
+    session, embedder, monkeypatch
+):
+    resolver = make_resolver(monkeypatch, [])
+    topic = make_topic("Diffusion Models")
+    comparison = ERComparison(
+        name_1="Diffusion Models",
+        type_1="Concept",
+        description_1="d1",
+        name_2="Diffusion",
+        type_2="Concept",
+        description_2="d2",
+        fts_score=1.0,
+        vss_distance=0.1,
+        decision_date="2026-08-10",
+        merge_topic=False,
+    )
+
+    extraction_topic = asyncio.run(
+        resolver._apply_decision(TopicERDecision(topic, [comparison], None), session)
+    )
+    session.commit()
+
+    assert extraction_topic.id is not None
+    assert extraction_topic.name == "Diffusion Models"
+    assert extraction_topic.type == "Concept"
+    assert embedder.embedded == ["description of Diffusion Models"]
+    assert session.exec(select(ERComparison)).scalars().all() == [comparison]
+
+
+def test_apply_decision_merges_in_place(session, embedder, monkeypatch):
+    topic_id = seed_topic(session, "BigQuery", TopicType.PLATFORM)
+    resolver = make_resolver(monkeypatch, [])
+    merged = make_topic("Google BigQuery", TopicType.TOOL)
+
+    extraction_topic = asyncio.run(
+        resolver._apply_decision(
+            TopicERDecision(merged, [], TopicMerge(topic_id, "BigQuery", "Platform")),
+            session,
+        )
+    )
+
+    assert extraction_topic.id == topic_id
+    assert extraction_topic.name == "Google BigQuery"
+    assert extraction_topic.type == "Tool"
+    assert session.exec(select(ExtractionTopic)).scalars().all() == [extraction_topic]
+
+
+# --- resolve_topics: end to end over a stub index ----------------------------
+
+
+def test_resolve_topics_skips_topics_already_in_db(session, embedder, monkeypatch):
+    seed_topic(session, "BigQuery", TopicType.PLATFORM)
+    resolver = make_resolver(monkeypatch, [])
+    monkeypatch.setattr(topic_er, "TopicsIndex", lambda: StubTopicsIndex({}))
+
+    resolved, merges = asyncio.run(
+        resolver.resolve_topics([make_topic("bigquery")], session)
+    )
+
+    # matched case-insensitively, so no ER call and no new row
+    assert [topic.name for topic in resolved] == ["BigQuery"]
+    assert merges == []
+    assert resolver.er_classifier.calls == []
+    assert embedder.embedded == []
+
+
+def test_resolve_topics_drops_llm_duplicates(session, embedder, monkeypatch):
+    resolver = make_resolver(monkeypatch, [])
+    monkeypatch.setattr(topic_er, "TopicsIndex", lambda: StubTopicsIndex({}))
+
+    resolved, _ = asyncio.run(
+        resolver.resolve_topics(
+            [make_topic("Diffusion Models"), make_topic("Diffusion Models")], session
+        )
+    )
+
+    assert len(resolved) == 1
+
+
+def test_resolve_topics_reports_every_merge(session, embedder, monkeypatch):
+    """Regression guard for #55.
+
+    The vault needs the pre-merge name/type of every merged topic to find the
+    notes it has to rewrite. This used to be read back from SQLAlchemy attribute
+    history, which any flush resets, so only one merge of a batch survived.
+    """
+    bigquery_id = seed_topic(session, "BigQuery", TopicType.PLATFORM)
+    stakeholder_id = seed_topic(session, "Stakeholder Management", TopicType.CONCEPT)
+
+    index = StubTopicsIndex(
+        {
+            "Google BigQuery": {
+                bigquery_id: make_topic("BigQuery", TopicType.PLATFORM)
+            },
+            "Stakeholder Management in Data Projects": {
+                stakeholder_id: make_topic("Stakeholder Management")
+            },
+        }
+    )
+    monkeypatch.setattr(topic_er, "TopicsIndex", lambda: index)
+
+    new_topics = [
+        make_topic("Google BigQuery", TopicType.TOOL),
+        make_topic("Stakeholder Management in Data Projects"),
+    ]
+    resolver = make_resolver(
+        monkeypatch, [merge_result(new_topics[0]), merge_result(new_topics[1])]
+    )
+
+    resolved, merges = asyncio.run(resolver.resolve_topics(new_topics, session))
+
+    assert sorted(topic.id for topic in resolved) == sorted(
+        [bigquery_id, stakeholder_id]
+    )
+
+    # every merge is reported, not just the last one to survive a flush
+    assert sorted(merges, key=lambda merge: merge.topic_id) == sorted(
+        [
+            TopicMerge(bigquery_id, "BigQuery", "Platform"),
+            TopicMerge(stakeholder_id, "Stakeholder Management", "Concept"),
+        ],
+        key=lambda merge: merge.topic_id,
+    )

--- a/tests/test_write_notes.py
+++ b/tests/test_write_notes.py
@@ -1,0 +1,152 @@
+from datetime import date
+
+import frontmatter
+import pytest
+from sqlmodel import Session
+
+from dsview.db.schemas import InputContent
+from dsview.db.schemas.extraction_schema import (
+    ContentTopicRelation,
+    ExtractionResult,
+    ExtractionTopic,
+)
+from dsview.extraction.topic_er import TopicMerge
+from dsview.obsidian.obsidian_utils import (
+    get_content_path,
+    get_topic_link,
+    get_topic_path,
+)
+from dsview.obsidian.write_notes import (
+    update_topic_note,
+    write_and_update_topic_list_notes,
+    write_topic_note,
+)
+
+
+@pytest.fixture
+def topic(session: Session) -> ExtractionTopic:
+    """A topic with its note already on disk, as an earlier ingestion left it."""
+    extraction_topic = ExtractionTopic(
+        name="BigQuery", type="Platform", description="a warehouse"
+    )
+    session.add(extraction_topic)
+    session.commit()
+
+    write_topic_note(extraction_topic)
+
+    return extraction_topic
+
+
+def link_content(
+    session: Session, topic: ExtractionTopic, title: str, topics: list[str]
+) -> InputContent:
+    """Link a content to `topic` and write its note embedding `topics`, in order."""
+    content = InputContent(
+        link=f"https://example.com/{title}", upload_date=date(2026, 1, 1)
+    )
+    session.add(content)
+    session.commit()
+
+    session.add(
+        ExtractionResult(
+            content_id=content.id,
+            title=title,
+            content_type="Blog post",
+            summary="summary",
+            embedding=None,
+        )
+    )
+    session.add(ContentTopicRelation(content_id=content.id, topic_id=topic.id))
+    session.commit()
+
+    body = "## Topics\n\n" + "\n\n".join(
+        get_topic_link(name, "Platform") for name in topics
+    )
+    note_path = get_content_path(title, "Blog post")
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(note_path, "w") as note_file:
+        frontmatter.dump(frontmatter.Post(body), note_file)
+
+    return content
+
+
+def rename(session: Session, topic: ExtractionTopic, name: str, type_: str):
+    topic.name = name
+    topic.type = type_
+    session.commit()
+
+
+# --- update_topic_note --------------------------------------------------------
+
+
+def test_renamed_topic_note_moves_and_content_embeds_follow(session, vault, topic):
+    # the merged topic is the *last* embed: frontmatter strips the trailing
+    # newlines, so a match on "link\n\n" would silently miss it
+    link_content(session, topic, "Title A", ["Pandas", "BigQuery"])
+    rename(session, topic, "Google BigQuery", "Tool")
+
+    update_topic_note(topic, "BigQuery", "Platform")
+
+    assert not get_topic_path("BigQuery", "Platform").exists()
+    assert get_topic_path("Google BigQuery", "Tool").exists()
+
+    note = frontmatter.load(get_content_path("Title A", "Blog post"))
+    assert get_topic_link("BigQuery", "Platform") not in note.content
+    assert get_topic_link("Google BigQuery", "Tool") in note.content
+    assert get_topic_link("Pandas", "Platform") in note.content
+
+
+def test_merge_keeping_name_and_type_rewrites_the_note_in_place(session, vault, topic):
+    # 40% of real merges keep the candidate's name, so the note deleted as "old"
+    # is the one being written again
+    topic.description = "a merged warehouse"
+    session.commit()
+
+    update_topic_note(topic, "BigQuery", "Platform")
+
+    note_path = get_topic_path("BigQuery", "Platform")
+    assert note_path.exists()
+    assert frontmatter.load(note_path).content == "a merged warehouse"
+
+
+def test_missing_content_note_is_skipped(session, vault, topic):
+    link_content(session, topic, "Title A", ["BigQuery"])
+    get_content_path("Title A", "Blog post").unlink()
+    rename(session, topic, "Google BigQuery", "Tool")
+
+    update_topic_note(topic, "BigQuery", "Platform")
+
+    # the ingestion is not aborted, and the renamed topic note is still written
+    assert get_topic_path("Google BigQuery", "Tool").exists()
+
+
+# --- write_and_update_topic_list_notes ----------------------------------------
+
+
+def test_merged_topic_is_updated_even_once_the_session_is_flushed(
+    session, vault, topic
+):
+    link_content(session, topic, "Title A", ["BigQuery"])
+    rename(session, topic, "Google BigQuery", "Tool")
+
+    # the commit above flushed, so inspect(topic).modified is False: routing must
+    # come from the merge list, not from ORM state
+    write_and_update_topic_list_notes(
+        [topic], [TopicMerge(topic.id, "BigQuery", "Platform")]
+    )
+
+    assert not get_topic_path("BigQuery", "Platform").exists()
+    note = frontmatter.load(get_content_path("Title A", "Blog post"))
+    assert get_topic_link("Google BigQuery", "Tool") in note.content
+
+
+def test_unmerged_topic_is_only_written(session, vault, topic):
+    content = link_content(session, topic, "Title A", ["BigQuery"])
+    note_before = get_content_path("Title A", "Blog post").read_text()
+
+    write_and_update_topic_list_notes([topic], [])
+
+    assert get_topic_path("BigQuery", "Platform").exists()
+    assert get_content_path("Title A", "Blog post").read_text() == note_before
+    assert content.id is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1071,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "dsview"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Keeps the Obsidian vault in sync with the DB across entity-resolution topic merges.

- **#54** — unique index on `lower(name)` for topics and on `(lower(title), content_type)` for
  contents, so case-only duplicates can't be created.
- **#55** — merges now propagate to the vault. The pre-merge name/type is carried explicitly out of
  the resolver (`TopicMerge`) instead of being read back from SQLAlchemy attribute history, which
  any flush resets — that silently broke every merge after the first in a batch. Also fixes the
  link rewrite missing a note's *last* topic embed, since `frontmatter.dumps` strips the trailing
  newlines it was matching on.
- **#56** — ER split out of `content_extraction.py` into `extraction/topic_er.py`, with the async
  LLM phase (`_resolve_topic`, touches no session) separated from a sequential write phase
  (`_apply_decision`). No more concurrent use of a shared `Session`.

Plus `dsview check-vault-sync` to audit DB/vault drift, and a shared `tests/conftest.py`
(in-memory SQLite + throwaway vault fixtures).

Existing drift is cleaned with `dsview reset` + `dsview regen-vault`; no prune step needed.

## Testing

139 passed offline. `test_batch.py::test_score_row_no_predictions` fails on `main` too.
`dsview --help` verified to still import with no config env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YWegqARVwvCuUZuF324C9
