### PR TITLE
Implement pydantic logfire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,9 @@ VAULT_REPOSITORY=your_repo_here
 GITHUB_USERNAME=user_for_auto_updates_here
 GITHUB_USER_EMAIL=user_email_for_auto_updates_here
 GITHUB_TOKEN=token_for_auto_updates_here
+
+# ================================
+# Logfire configuration
+# ================================
+
+LOGFIRE_TOKEN=logfire_write_token

--- a/.env.example
+++ b/.env.example
@@ -58,4 +58,6 @@ GITHUB_TOKEN=token_for_auto_updates_here
 # Logfire configuration
 # ================================
 
+# Define logfire token and enable send to logfire to enable it
 LOGFIRE_TOKEN=logfire_write_token
+LOGFIRE_SEND_TO_LOGFIRE=false

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ and methodologies. It implements a similar concept to Karpathy's LLM wiki, a kno
 interconnected markdown serving at a knowledge base. It was mostly inspired by Obsidian, but aimed to 
 circumvent the time consuming manual construction of the graph.
 
-The need of DSview from the growing AI and data ecosystem, and the never stopping flow of information. 
-It is not supposed to represent what a DS actually knows, but efficiently store concepts and tools so they
-can be reused later.
-
 The user workflow has also been optimized to be as easy to use as possible, so that it is never in the way.
 Adding some new content is just a few click away and runs in the background.
+Retrieving and exploring the knowledge base is also supposed to be painless and fast, a lot of the heavy lifting on this topic comes from obsidian. The project also implements a MCP server, that allows agents to autonomously explore and retrieve informatino for the vault.

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -2,27 +2,18 @@ version: 1
 disable_existing_loggers: false
 
 formatters:
-  rich_formatter:
+  simple_formatter:
     format: "%(message)s"
-  file_formatter:
-    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 handlers:
   console:
     class: rich.logging.RichHandler
-    level: DEBUG
-    formatter: rich_formatter
+    level: INFO
+    formatter: simple_formatter
     rich_tracebacks: true
     markup: true
-
-  file:
-    class: logging.FileHandler
-    level: INFO
-    formatter: file_formatter
-    filename: "run_dsview.log"
-    encoding: "utf-8"
 
 loggers:
   root:
     level: INFO
-    handlers: [console, file]
+    handlers: [console]

--- a/config/model.yaml
+++ b/config/model.yaml
@@ -1,4 +1,23 @@
 configs:
+  # - model_type: DEFAULT
+  #   model_config:
+  #     chat_model: claude-sonnet-5
+  #     provider: ANTHROPIC
+  #     token_limit: 256000
+  #     model_specific_config:
+  #       max_tokens: 10000
+  #       # temperature: 0
+  # - model_type: INDEX
+  #   model_config:
+  #     # host: https://llm.lab.sspcloud.fr/api
+  #     # chat_model: mistral-small3.2:latest
+  #     chat_model: mistral-small-2603
+  #     embedding_model: mistral-embed
+  #     # provider: OPENAI
+  #     provider: MISTRAL
+  #     token_limit: 256000
+  #     model_specific_config:
+  #       temperature: 0
   - model_type: DEFAULT
     model_config:
       # host: https://llm.lab.sspcloud.fr/api

--- a/config/model.yaml
+++ b/config/model.yaml
@@ -1,23 +1,4 @@
 configs:
-  # - model_type: DEFAULT
-  #   model_config:
-  #     chat_model: claude-sonnet-5
-  #     provider: ANTHROPIC
-  #     token_limit: 256000
-  #     model_specific_config:
-  #       max_tokens: 10000
-  #       # temperature: 0
-  # - model_type: INDEX
-  #   model_config:
-  #     # host: https://llm.lab.sspcloud.fr/api
-  #     # chat_model: mistral-small3.2:latest
-  #     chat_model: mistral-small-2603
-  #     embedding_model: mistral-embed
-  #     # provider: OPENAI
-  #     provider: MISTRAL
-  #     token_limit: 256000
-  #     model_specific_config:
-  #       temperature: 0
   - model_type: DEFAULT
     model_config:
       # host: https://llm.lab.sspcloud.fr/api

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -1,5 +1,5 @@
 obsidian:
-  vault_path: dsview_vault_test
+  vault_path: dsview_vault
   content_directory: "contents"
   topic_directory: "topics"
 postgres:

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -1,5 +1,5 @@
 obsidian:
-  vault_path: dsview_vault
+  vault_path: dsview_vault_test
   content_directory: "contents"
   topic_directory: "topics"
 postgres:

--- a/dsview/api.py
+++ b/dsview/api.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Request
+import logfire
 from pydantic import HttpUrl
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session
@@ -13,7 +14,11 @@ from tenacity import RetryError
 from dsview.config import setup_logger
 from dsview.db import engine, check_db_connection
 from dsview.db.ingest import update_content
-from dsview.db.query import get_content_extraction, get_failed_ingestion
+from dsview.db.query import (
+    get_content_by_id,
+    get_content_extraction,
+    get_failed_ingestion,
+)
 from dsview.db.schemas import InputContent
 from dsview.ingest_source import IngestPipeline
 from dsview.obsidian.sync_vault import (
@@ -28,14 +33,33 @@ from dsview.obsidian.sync_vault import (
 # TODO merge setup and sync_vault
 
 load_dotenv()
-setup_logger()
+setup_logger(enable_logfire=True, service_name="dsview-api")
 init_vault()
 
 logger = logging.getLogger(__name__)
 
+# Built after logfire.configure(): constructing a Mistral provider imports
+# providers/mistral.py, which runs MistralAIInstrumentor().instrument() at import
+# and binds whatever tracer provider is current.
 ingest_pipeline = IngestPipeline()
 
 app = FastAPI()
+
+logfire.instrument_fastapi(app)
+# logfire.instrument_sqlalchemy(engine=engine)
+# Instrumenting sqlalchemy won't be really usefull because the
+# database is tiny
+
+session_content_request = logfire.metric_counter(
+    name="session_content_request",
+    unit="1",
+    description="Number of api ingestion request since last deployment",
+)
+session_failed_ingestion = logfire.metric_counter(
+    name="session_failed_ingestion",
+    unit="1",
+    description="Number of failed ingestion since last deployment",
+)
 
 
 @app.exception_handler(HTTPException)
@@ -79,27 +103,37 @@ def _log_background_ingest_result(task: asyncio.Task) -> None:
     logger.error("Background ingest task failed: %s", exc, exc_info=exc)
 
 
-async def _run_ingest_and_sync(content: InputContent) -> Exception | None:
+async def _run_ingest_and_sync(content_id: int) -> None:
+    # The row was committed by the request handler, so it is re-read by id here
+    # rather than carried over: the request session is closed by now and the
+    # instance detached from it.
     with Session(engine) as session:
-        error = await ingest_pipeline.async_ingest_content(content, session)
-        # ContentAlreadyExists, if raised, propagates out of this block and out of
-        # this function to whoever is awaiting/tracking the task.
+        content = get_content_by_id(content_id, session)
+        link = str(content.link)
+
+        error = await ingest_pipeline.async_ingest_content(
+            content, session, already_saved=True
+        )
 
     if error is None and vault_config.github_vault.repository is not None:
         try:
             await async_upload_changes("Adding content")
         except CommandFailed:
-            logger.exception(
-                "Failed to push vault changes after ingesting %s", content.link
-            )
+            logger.exception("Failed to push vault changes after ingesting %s", link)
 
-    return error
+    # Re-raised so the task records it and it surfaces as a failure rather than
+    # being swallowed by the background task.
+    if error is not None:
+        session_failed_ingestion.add(1)
+        raise error
 
 
 @app.post("/ingest")
 async def ingest(content: InputContent, session: SessionDep):
     # validate content
     check_db_connection(session)
+
+    session_content_request.add(1)
 
     content = InputContent.model_validate(content)
 
@@ -115,7 +149,11 @@ async def ingest(content: InputContent, session: SessionDep):
     if vault_config.github_vault.repository is not None:
         await async_pull_changes()
 
-    task = asyncio.create_task(_run_ingest_and_sync(content))
+    # Committed before returning 202 so that polling /ingest/status immediately
+    # reports "pending" rather than 404-ing on a row the task hasn't written yet.
+    content = ingest_pipeline.register_content(content, session)
+
+    task = asyncio.create_task(_run_ingest_and_sync(content.id))
     _track_background_ingest(task)
 
     return JSONResponse(
@@ -134,13 +172,24 @@ async def ingest(content: InputContent, session: SessionDep):
 async def ingest_status(link: HttpUrl, session: SessionDep):
     content = ingest_pipeline.get_existing_content(link, session)
 
+    # /ingest commits the content row before returning, so a missing row means
+    # the link was never submitted. Returned rather than raised: the
+    # HTTPException handler would rewrite the body to status "error".
     if content is None:
-        return {"status": "pending"}
+        return JSONResponse(
+            status_code=404,
+            content={
+                "status": "unknown",
+                "detail": f"No ingestion found for link {link}",
+            },
+        )
 
     extraction_results, _, _ = get_content_extraction(content.id, session)
     if extraction_results:
         return {"status": "success"}
 
+    # The ingestion failed, but reporting that status is a success: the state
+    # belongs in the body, not in the status code.
     failed = get_failed_ingestion(content.id, session)
     if failed is not None:
         return {
@@ -148,7 +197,7 @@ async def ingest_status(link: HttpUrl, session: SessionDep):
             "detail": failed.error_message,
         }
 
-    return {"status": "pending"}
+    return JSONResponse(status_code=202, content={"status": "pending"})
 
 
 @app.patch("/relevance")

--- a/dsview/cli.py
+++ b/dsview/cli.py
@@ -4,6 +4,7 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+import logfire
 import typer
 from dotenv import load_dotenv
 from sqlmodel import Session
@@ -33,7 +34,7 @@ app = typer.Typer(
 def cli_setup():
     # Runs before any command (but not for --help), so a bare `dsview --help`
     # works without CONF_DIR or database environment variables.
-    setup_logger()
+    setup_logger(enable_logfire=True, service_name="dsview_cli")
 
 
 app.add_typer(evaluate_app, name="evaluate")
@@ -97,6 +98,7 @@ def backup():
 
 
 @app.command(help="Ingest a single piece of content from a URL or link")
+@logfire.instrument("Manual ingestion")
 def ingest(
     link: str = typer.Argument(..., help="URL or link to the content to ingest"),
     already_read: bool = typer.Option(False, help="Mark content as already read"),
@@ -133,6 +135,7 @@ def ingest(
 
 
 @app.command(help="Retry processing of previously failed ingestions")
+@logfire.instrument("Retrying failed ingestions ")
 def retry_failed(
     ignore: list[str] = ["WebRequestFailure"],
 ):
@@ -142,23 +145,24 @@ def retry_failed(
     """
     from .ingest_source import IngestPipeline
 
-    logger.info("Retrying failed ingestions ...")
+    logger.info("Retrying failed ingestions excluding : %s", ",".join(ignore))
 
     with Session(db.engine) as session:
         ingest_pipeline = IngestPipeline(rebuild_mode=True)
 
         content_list = get_failed_ingestions(session, ignore_errors=ignore)
 
-        logger.info("Found %s failed ingestions", len(content_list))
+        n_failed_content = len(content_list)
+        logfire.info(f"Found {n_failed_content} failed ingestions")
 
     schemas.drop_tables([schemas.FailedIngestion], db.engine, reset=True)
 
     with Session(db.engine) as session:
-        logger.info("Starting ingestions ...")
         ingest_pipeline.ingest_content_list(content_list, session)
 
 
 @app.command(help="Rebuild content processing for a range of content IDs")
+@logfire.instrument("Full knowledge base rebuild")
 def rebuild(
     start: int = typer.Option(0, help="Starting content ID (inclusive)"),
     end: int = typer.Option(
@@ -171,8 +175,6 @@ def rebuild(
     """
     from .ingest_source import IngestPipeline
 
-    # mlflow.set_experiment(experiment_name="Rebuild tasks")
-
     ingest_pipeline = IngestPipeline(rebuild_mode=True)
 
     with Session(db.engine) as session:
@@ -181,6 +183,9 @@ def rebuild(
             start_id=start,
             end_id=end,
         )
+
+        n_content = len(content_list)
+        logfire.info(f"Rebuilding extraction for {n_content} content")
 
         ingest_pipeline.ingest_content_list(content_list, session)
 

--- a/dsview/cli.py
+++ b/dsview/cli.py
@@ -135,7 +135,7 @@ def ingest(
 
 
 @app.command(help="Retry processing of previously failed ingestions")
-@logfire.instrument("Retrying failed ingestions ")
+@logfire.instrument("Retrying failed ingestions")
 def retry_failed(
     ignore: list[str] = ["WebRequestFailure"],
 ):

--- a/dsview/config.py
+++ b/dsview/config.py
@@ -247,9 +247,11 @@ def setup_logger(enable_logfire: bool = False, service_name: str | None = None):
 
         from dsview.model_utils.observability import MistralUsageSpanProcessor
 
+        send_to_logfire = False if "PYTEST_VERSION" in os.environ else "if-token-present"
+
         logfire.configure(
             console=False,
-            send_to_logfire="if-token-present",
+            send_to_logfire=send_to_logfire,
             service_name=service_name,
             additional_span_processors=[MistralUsageSpanProcessor()],
         )

--- a/dsview/config.py
+++ b/dsview/config.py
@@ -231,7 +231,27 @@ def load_postgres_config() -> PostgresConfig:
     return load_storage_config().postgres
 
 
-def setup_logger():
+def setup_logger(enable_logfire: bool = False, service_name: str | None = None):
     with open(Path(os.getenv("CONF_DIR")) / "logging.yaml") as config_file:
         logging_config = yaml.safe_load(config_file)
     logging.config.dictConfig(logging_config)
+
+    if enable_logfire:
+        if service_name is None:
+            raise ValueError("service_name must be provided if enable_logfire is True")
+
+        # Imported here rather than at module scope: anything under `model_utils`
+        # pulls in its `__init__`, which imports this module back. By call time
+        # `dsview.config` is fully initialized, so the cycle never forms.
+        import logfire
+
+        from dsview.model_utils.observability import MistralUsageSpanProcessor
+
+        logfire.configure(
+            console=False,
+            send_to_logfire="if-token-present",
+            service_name=service_name,
+            additional_span_processors=[MistralUsageSpanProcessor()],
+        )
+
+        logging.getLogger().addHandler(logfire.LogfireLoggingHandler())

--- a/dsview/db/query/__init__.py
+++ b/dsview/db/query/__init__.py
@@ -1,5 +1,6 @@
 from .query_content import (
     get_content,
+    get_content_by_id,
     get_content_list,
     get_failed_ingestion,
     get_failed_ingestions,

--- a/dsview/db/query/query_content.py
+++ b/dsview/db/query/query_content.py
@@ -12,6 +12,13 @@ def get_content(
     return session.exec(select(InputContent).where(InputContent.link == link)).first()
 
 
+def get_content_by_id(
+    content_id: int,
+    session: Session,
+) -> InputContent | None:
+    return session.get(InputContent, content_id)
+
+
 def get_content_list(
     session: Session,
     start_id: int = 1,

--- a/dsview/db/query/query_utils.py
+++ b/dsview/db/query/query_utils.py
@@ -1,5 +1,6 @@
 import logging
 
+import logfire
 import duckdb
 import pandas as pd
 
@@ -108,12 +109,12 @@ class DuckDBIndex:
         self.conn.execute(create_index_query)
 
     def build(self):
-        self.conn = self._init_duckdb()
-        self._create_index_table()
+        with logfire.span("Building indexes"):
+            self.conn = self._init_duckdb()
+            self._create_index_table()
 
-        logger.info("Creating indexes")
-        self._build_fts_index()
-        self._build_vss_index()
+            self._build_fts_index()
+            self._build_vss_index()
 
     def close(self):
         self.conn.close()

--- a/dsview/extraction/content_extraction.py
+++ b/dsview/extraction/content_extraction.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 
+import logfire
 from sqlmodel import Session
 
 from dsview.db.ingest import embed_and_format_extraction_results
@@ -34,6 +35,7 @@ class ContentExtractor:
         self.link_extractor = LinksExtractor()
         self.topic_resolver = TopicResolver()
 
+    @logfire.instrument("Extraction LLM calls")
     async def run_extraction(
         self, content_loader: ContentLoader
     ) -> tuple[str, ContentDescription, list[DataScienceTopic], list[RelevantLink]]:
@@ -63,11 +65,10 @@ class ContentExtractor:
             result = await asyncio.gather(*tasks)
             return result[0], result[1], result[2].topics, None
 
+    @logfire.instrument("Content extraction")
     async def extract_content(
         self, content_loader: ContentLoader, session: Session, content_id: int
     ) -> tuple[ExtractionResult, list[TopicMerge]]:
-        starting_time = time.perf_counter()
-
         (
             summary,
             content_description,
@@ -75,21 +76,14 @@ class ContentExtractor:
             content_links,
         ) = await self.run_extraction(content_loader)
 
-        logger.info("Saving extraction results")
-
-        extraction_result = await embed_and_format_extraction_results(
-            summary,
-            content_description,
-            content_links,
-            content_id,
-            session,
-        )
-
-        logger.info(
-            f"Total time for extraction: {time.perf_counter() - starting_time:.1f} seconds"
-        )
-
-        logger.info("Launching topic ER")
+        with logfire.span("Saving extraction results"):
+            extraction_result = await embed_and_format_extraction_results(
+                summary,
+                content_description,
+                content_links,
+                content_id,
+                session,
+            )
 
         (
             extraction_result.topics,

--- a/dsview/extraction/content_loader.py
+++ b/dsview/extraction/content_loader.py
@@ -11,6 +11,7 @@ from urllib.parse import parse_qs, quote, urlparse
 
 import requests
 import tiktoken
+import logfire
 from bs4 import BeautifulSoup
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
@@ -27,6 +28,8 @@ from dsview.config import load_model_config
 REQUEST_TIMEOUT = 60
 
 _MARKDOWN_PARSER = MarkdownIt()
+
+logfire.instrument_requests()
 
 if TYPE_CHECKING:
     # docling pulls in torch/transformers - only imported for real inside the
@@ -56,9 +59,11 @@ class ContentLoader(ABC):
         pass
 
     def load(self):
-        logger.info("Loading content with %s", self.__class__.__name__)
+        if self.content is not None:
+            return
 
-        if self.content is None:
+        with logfire.span("Content loading"):
+            logger.info("Loading content with %s", self.__class__.__name__)
             self._load_content()
 
 
@@ -126,11 +131,13 @@ class PdfUrlLoader(WebContentLoader):
             temp_pdf.write(response.content)
             temp_pdf.flush()
 
-            result = self._get_pdf_converter().convert(temp_pdf.name)
-            self._extract_pdf_content(result)
+            with logfire.span("Exporting pdf to markdown"):
+                result = self._get_pdf_converter().convert(temp_pdf.name)
+                self._extract_pdf_content(result)
 
     def _extract_pdf_content(self, result: "ConversionResult"):
         token_limit = load_model_config().token_limit / 2
+
         full_content = result.document.export_to_markdown()
 
         chunker, count_tokens = self._get_pdf_chunker()
@@ -503,9 +510,6 @@ class YoutubeContentLoader(WebContentLoader):
             raise YoutubeTranscriptUnavailable(self.video_id, str(error)) from error
 
         return " ".join(snippet.text for snippet in fetched)
-
-
-# ? How to deal with token_limit
 
 
 YOUTUBE_HOSTS = YoutubeContentLoader.WATCH_HOSTS | {YoutubeContentLoader.SHORT_HOST}

--- a/dsview/extraction/topic_er.py
+++ b/dsview/extraction/topic_er.py
@@ -49,8 +49,6 @@ def _dedup_resolved(topics: list[ExtractionTopic]) -> list[ExtractionTopic]:
             seen_ids.add(topic.id)
         deduped.append(topic)
 
-    # logger.info("Number of topics after ER dedup : %s", len(deduped))
-
     return deduped
 
 

--- a/dsview/extraction/topic_er.py
+++ b/dsview/extraction/topic_er.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 
+import logfire
 from sqlmodel import Session
 
 from dsview.db.ingest import (
@@ -48,7 +49,7 @@ def _dedup_resolved(topics: list[ExtractionTopic]) -> list[ExtractionTopic]:
             seen_ids.add(topic.id)
         deduped.append(topic)
 
-    logger.info("Number of topics after ER dedup : %s", len(deduped))
+    # logger.info("Number of topics after ER dedup : %s", len(deduped))
 
     return deduped
 
@@ -79,7 +80,7 @@ class TopicResolver:
             )
 
             if result.merge_topic:
-                logger.warning(
+                logger.info(
                     "Merging topics %s and %s into %s ",
                     topic.name,
                     candidate_topic.name,
@@ -114,6 +115,7 @@ class TopicResolver:
 
         return await embed_and_save_topic(decision.topic, session)
 
+    @logfire.instrument("Resolving topics")
     async def resolve_topics(
         self, topics: list[DataScienceTopic], session: Session
     ) -> tuple[list[ExtractionTopic], list[TopicMerge]]:
@@ -129,7 +131,7 @@ class TopicResolver:
                 existing_topic = get_topic_by_name(topic.name, session)
 
                 if existing_topic is not None:
-                    logger.warning("Topic %s already exists", topic.name)
+                    logger.info("Topic %s already exists", topic.name)
                     existing_topics.append(existing_topic)
                     continue
 
@@ -146,4 +148,9 @@ class TopicResolver:
             decision.merge for decision in decisions if decision.merge is not None
         ]
 
-        return _dedup_resolved(extraction_topics + existing_topics), merges
+        resolved_topics = _dedup_resolved(extraction_topics + existing_topics)
+
+        n_resolved_topics = len(resolved_topics)
+        logfire.info(f"Number of topics after ER : {n_resolved_topics}")
+
+        return resolved_topics, merges

--- a/dsview/ingest_source.py
+++ b/dsview/ingest_source.py
@@ -1,7 +1,9 @@
 import asyncio
+from functools import lru_cache
 import logging
 from urllib.parse import urlunparse
 
+import logfire
 from pydantic import HttpUrl
 from rich.progress import track
 from sqlmodel import Session
@@ -26,38 +28,34 @@ MEDIUM_HOSTS = ["medium.com", "towardsdatascience.com", "netflixtechblog.com"]
 IGNORE_CLEAN_HOSTS = list(YOUTUBE_HOSTS)
 
 
+@lru_cache(maxsize=100)
+def clean_content_url(link: HttpUrl) -> HttpUrl:
+    # remove query and fragment from url
+
+    if link.host not in IGNORE_CLEAN_HOSTS:
+        clean_url = HttpUrl(urlunparse((link.scheme, link.host, link.path, "", "", "")))
+    else:
+        clean_url = link
+
+    if clean_url.host in MEDIUM_HOSTS:
+        logger.info("Received a medium link, redirecting to readmedium")
+        clean_url = HttpUrl("https://readmedium.com/" + link.path)
+
+    return clean_url
+
+
 class IngestPipeline:
     def __init__(self, rebuild_mode: bool = False):
         self.content_extractor = ContentExtractor()
         self.rebuild_mode = rebuild_mode
 
-    def _clean_content_url(self, link: HttpUrl) -> HttpUrl:
-        # remove query and fragment from url
-
-        logger.info("Cleaning content url")
-
-        if link.host not in IGNORE_CLEAN_HOSTS:
-            clean_url = HttpUrl(
-                urlunparse((link.scheme, link.host, link.path, "", "", ""))
-            )
-        else:
-            clean_url = link
-
-        if clean_url.host in MEDIUM_HOSTS:
-            logger.info("Received a medium link, redirecting to readmedium")
-            clean_url = HttpUrl("https://readmedium.com/" + link.path)
-
-        return clean_url
-
     def get_existing_content(
         self, link: HttpUrl, session: Session
     ) -> InputContent | None:
-        return get_content(self._clean_content_url(link), session)
+        return get_content(clean_content_url(link), session)
 
     # make ingest_source load
     def _load(self, content: InputContent) -> ContentLoader:
-        logger.info("Loading input content")
-
         content_loader = get_content_loader(content.link)
         content_loader.load()
 
@@ -66,7 +64,6 @@ class IngestPipeline:
     async def _extract(
         self, content_loader: ContentLoader, content_id: int, session: Session
     ) -> tuple[ExtractionResult, list[TopicMerge]]:
-        logger.info("Launching content extraction")
 
         return await self.content_extractor.extract_content(
             content_loader,
@@ -74,6 +71,7 @@ class IngestPipeline:
             content_id,
         )
 
+    @logfire.instrument("Updating vault")
     def _write(
         self,
         content: InputContent,
@@ -88,15 +86,30 @@ class IngestPipeline:
             extraction_result.topics, topic_merges
         )
 
+    def register_content(self, content: InputContent, session: Session) -> InputContent:
+        """Persist the content row before any ingestion work happens.
+
+        Lets a caller that ingests in the background commit the row up front, so
+        that a later status lookup can tell an unknown link apart from an
+        ingestion that simply hasn't written anything yet.
+        """
+        if isinstance(content.link, HttpUrl):
+            content.link = clean_content_url(content.link)
+
+        content = save_content(content, session)
+        session.commit()
+
+        return content
+
     async def async_ingest_content(
-        self, content: InputContent, session: Session
+        self, content: InputContent, session: Session, already_saved: bool = False
     ) -> Exception | None:
         original_link = str(content.link)
 
         if isinstance(content.link, HttpUrl):
-            content.link = self._clean_content_url(content.link)
+            content.link = clean_content_url(content.link)
 
-        if not self.rebuild_mode:
+        if not self.rebuild_mode and not already_saved:
             content = save_content(content, session)
             session.commit()
 
@@ -128,6 +141,7 @@ class IngestPipeline:
         session.commit()
         return error
 
+    @logfire.instrument("Ingestion pipeline")
     def ingest_content(self, content: InputContent, session: Session):
         asyncio.run(self.async_ingest_content(content, session))
 

--- a/dsview/interface/dashboard/content_dashboard.py
+++ b/dsview/interface/dashboard/content_dashboard.py
@@ -209,7 +209,7 @@ def fetch_note_summary(engine, mo, selected_content):
         WHERE content_id = {selected_content["id"]}
         """,
         output=False,
-        engine=engine
+        engine=engine,
     )
     return (note_summary,)
 

--- a/dsview/interface/dashboard/content_dashboard.py
+++ b/dsview/interface/dashboard/content_dashboard.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.14.16"
+__generated_with = "0.23.14"
 app = marimo.App(
     width="medium",
     layout_file="layouts/content_dashboard.grid.json",
@@ -44,7 +44,9 @@ def _(get_sidebar):
 
 @app.cell
 def _(mo):
-    mo.md(r"""## Sources""")
+    mo.md(r"""
+    ## Sources
+    """)
     return
 
 
@@ -55,7 +57,7 @@ def _(mo):
 
 
 @app.cell
-def _(engine, extractionresult, get_refresh, inputcontent, mo):
+def _(engine, get_refresh, mo):
     get_refresh()
 
     sources = mo.sql(
@@ -84,7 +86,9 @@ def _(engine, extractionresult, get_refresh, inputcontent, mo):
 
 @app.cell
 def _(mo):
-    mo.md(r"""## Display and filter""")
+    mo.md(r"""
+    ## Display and filter
+    """)
     return
 
 
@@ -165,7 +169,9 @@ def _(filtered_priority_sources, relevance_chart):
 
 @app.cell
 def _(mo):
-    mo.md(r"""## Display sources""")
+    mo.md(r"""
+    ## Display sources
+    """)
     return
 
 
@@ -193,7 +199,7 @@ def _(mo, sources_table):
 
 
 @app.cell
-def fetch_note_summary(engine, extractionresult, mo, selected_content):
+def fetch_note_summary(engine, mo, selected_content):
     note_summary = mo.sql(
         f"""
         Select
@@ -203,7 +209,7 @@ def fetch_note_summary(engine, extractionresult, mo, selected_content):
         WHERE content_id = {selected_content["id"]}
         """,
         output=False,
-        engine=engine,
+        engine=engine
     )
     return (note_summary,)
 
@@ -226,7 +232,9 @@ def _(mo, note_summary):
 
 @app.cell
 def _(mo):
-    mo.md(r"""## Update form""")
+    mo.md(r"""
+    ## Update form
+    """)
     return
 
 
@@ -303,6 +311,7 @@ def _(
             read_priority=read_priority.value,
             relevance=content_relevance.value,
         )
+        session.commit()
 
     set_refresh(0)
     return

--- a/dsview/mcp/server.py
+++ b/dsview/mcp/server.py
@@ -5,6 +5,7 @@ from datetime import date
 from functools import lru_cache
 from typing import Annotated, Literal, Optional
 
+import logfire
 import igraph as ig
 from mcp.server.fastmcp import FastMCP, Icon
 from pydantic import BaseModel, Field
@@ -12,17 +13,21 @@ from sqlmodel import Session
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
-from dsview.config import lazy, load_extraction_config
+from dsview.config import lazy, load_extraction_config, setup_logger
 from dsview.db import engine
 from dsview.db.query import ExtractionIndex, TopicsIndex, get_filtered_content
 from dsview.db.schemas import ExtractionResult, ExtractionTopic, InputContent
 from dsview.graph import build_graph, get_node_neighborhood, get_ranked_nodes
 
+INDEX_TTL = 3_600
+
+setup_logger(enable_logfire=True, service_name="dsview_mcp")
+
 # TODO maybe should handle async calls ?
 logger = logging.getLogger(__name__)
 extraction_config = lazy(load_extraction_config)
 
-INDEX_TTL = 3_600
+logfire.instrument_mcp()
 
 
 def get_ttl_hash(seconds: int):

--- a/dsview/model_utils/observability.py
+++ b/dsview/model_utils/observability.py
@@ -115,7 +115,21 @@ class MistralUsageSpanProcessor(SpanProcessor):
         # pipeline in a MainSpanProcessorWrapper that rebuilds every span through
         # `span_to_dict`, which reads the immutable `ReadableSpan.attributes`
         # property, so the span we get here holds a mappingproxy.
-        span._attributes = {**attributes, **new_attributes}
+        #
+        # `_attributes` is a private opentelemetry-sdk attribute, not a published
+        # API - assert the assumption instead of silently no-op'ing if it ever
+        # stops holding. `on_end` runs inline in the real Mistral call path
+        # (`SynchronousMultiSpanProcessor` has no try/except around processors), so
+        # the assertion failure must not propagate into a live call - only observability
+        # breaks, not ingestion.
+        try:
+            assert hasattr(span, "_attributes"), (
+                "ReadableSpan has no _attributes to rewrite; "
+                "opentelemetry-sdk's internals may have changed"
+            )
+            span._attributes = {**attributes, **new_attributes}
+        except AssertionError:
+            logger.error("Could not rewrite Mistral span attributes", exc_info=True)
 
 
 # A plain OTel tracer rather than `logfire.span()`: the entrypoints that never call

--- a/dsview/model_utils/observability.py
+++ b/dsview/model_utils/observability.py
@@ -1,0 +1,182 @@
+"""Make the OpenInference Mistral spans legible to Logfire's LLM features.
+
+Logfire translates OpenInference attributes into the shape its LLM views expect —
+OTel GenAI semantic conventions for tokens and cost, an 'LLM' tag, and
+request/response payloads for the Generation panel — but only for the langchain,
+langsmith and litellm scopes (see `logfire._internal.exporters.processor_wrapper`).
+Mistral spans therefore arrive carrying `llm.*` names that nothing reads, and show
+up as ordinary spans with neither tokens, price, nor a conversation view.
+
+This does for the Mistral scope what logfire's own `_transform_litellm_span` does
+for litellm, and mirrors its choices. Price is derived by the Logfire backend from
+the semconv attributes — the translations logfire ships never set `operation.cost`
+themselves — so there is deliberately no price computation here.
+
+Embeddings need the opposite treatment: OpenInference wraps Mistral's chat methods
+but not `Embeddings.create`, so there is no span to rewrite and `embedding_span`
+emits one instead.
+"""
+
+import json
+import logging
+from contextlib import contextmanager
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import SpanKind
+
+logger = logging.getLogger(__name__)
+
+MISTRAL_SCOPE = "openinference.instrumentation.mistralai"
+
+PROMPT_TOKENS = "llm.token_count.prompt"
+
+# OpenInference attribute -> OTel GenAI semantic convention attribute.
+SEMCONV_RENAMES = {
+    "llm.model_name": "gen_ai.request.model",
+    PROMPT_TOKENS: "gen_ai.usage.input_tokens",
+    "llm.token_count.completion": "gen_ai.usage.output_tokens",
+}
+
+# The 'LLM' tag is what switches on logfire's LLM features; request_data and
+# response_data are what its Generation panel renders, and the schema tells the
+# backend to parse those two as JSON instead of displaying them as strings.
+TAGS_KEY = "logfire.tags"
+JSON_SCHEMA_KEY = "logfire.json_schema"
+PAYLOAD_JSON_SCHEMA = (
+    '{"type":"object","properties":'
+    '{"request_data":{"type":"object"},"response_data":{"type":"object"}}}'
+)
+EMBEDDING_JSON_SCHEMA = (
+    '{"type":"object","properties":'
+    '{"request_data":{"type":"object"},"response_data":{"type":"object"},'
+    '"gen_ai.usage.raw":{"type":"object"}}}'
+)
+
+
+def _payload_attributes(attributes) -> dict:
+    """Recast the OpenInference request/response blobs for the Generation panel.
+
+    `output.value` is the whole ChatCompletionResponse as JSON, so the assistant
+    message and the responding model both come out of it.
+    """
+    try:
+        response = json.loads(attributes["output.value"])
+        payload = {
+            "request_data": attributes["input.value"],
+            "response_data": json.dumps({"message": response["choices"][0]["message"]}),
+            JSON_SCHEMA_KEY: PAYLOAD_JSON_SCHEMA,
+        }
+
+        if "model" in response:
+            payload["gen_ai.response.model"] = response["model"]
+
+        return payload
+
+    except Exception:
+        logger.debug("Could not read Mistral span payload", exc_info=True)
+        return {}
+
+
+class MistralUsageSpanProcessor(SpanProcessor):
+    """Rewrite OpenInference Mistral spans into the form logfire's LLM views read."""
+
+    def on_end(self, span: ReadableSpan) -> None:
+        scope = span.instrumentation_scope
+
+        if scope is None or scope.name != MISTRAL_SCOPE:
+            return
+
+        attributes = span.attributes
+
+        # No token count means this isn't a model request. Tagging it as one would
+        # double count cost in the UI.
+        if attributes is None or PROMPT_TOKENS not in attributes:
+            return
+
+        new_attributes = {
+            target: attributes[source]
+            for source, target in SEMCONV_RENAMES.items()
+            if source in attributes
+        }
+
+        # `gen_ai.system` is the older spelling of `gen_ai.provider.name`; logfire
+        # writes both, so match it.
+        new_attributes["gen_ai.system"] = new_attributes["gen_ai.provider.name"] = (
+            "mistral"
+        )
+        # What logfire's native integrations tag a completion with, and what its
+        # LLM/providers dashboard filters on.
+        new_attributes["gen_ai.operation.name"] = "chat"
+        new_attributes[TAGS_KEY] = ["LLM"]
+        new_attributes.update(_payload_attributes(attributes))
+
+        # Replace the mapping rather than assigning into it. Logfire wraps the whole
+        # pipeline in a MainSpanProcessorWrapper that rebuilds every span through
+        # `span_to_dict`, which reads the immutable `ReadableSpan.attributes`
+        # property, so the span we get here holds a mappingproxy.
+        span._attributes = {**attributes, **new_attributes}
+
+
+# A plain OTel tracer rather than `logfire.span()`: the entrypoints that never call
+# `logfire.configure()` (CLI, evals, notebooks) then get a silent no-op tracer instead
+# of a LogfireNotConfiguredWarning. Resolves the global provider lazily, so importing
+# this module before `logfire.configure()` is fine.
+EMBEDDINGS_TRACER = trace.get_tracer("dsview.embeddings")
+
+
+def _embedding_response_attributes(response) -> dict:
+    """Model, usage and vector width — never the vectors themselves.
+
+    Mirrors logfire's own embeddings handling, which sets `response_data` to just
+    `{"usage": ...}`, plus the two things it can't derive from an OpenAI response:
+    the dimension count, and an explicit 0 for output tokens. Logfire omits the
+    latter only because OpenAI's embedding usage object has no such field.
+    """
+    try:
+        usage = response.usage.model_dump(exclude_none=True)
+
+        return {
+            "gen_ai.response.model": response.model,
+            "gen_ai.usage.input_tokens": response.usage.prompt_tokens,
+            "gen_ai.usage.output_tokens": 0,
+            # `gen_ai.embeddings.dimension.count` is the semantic convention for
+            # vector width; reading it off the response keeps the vector out of the
+            # span while still reporting its size.
+            "gen_ai.embeddings.dimension.count": len(response.data[0].embedding),
+            # The provider-native usage blob, which is what genai-prices reads to
+            # derive a price. Logfire sets it alongside the token counts.
+            "gen_ai.usage.raw": json.dumps(usage),
+            "response_data": json.dumps({"usage": usage}),
+        }
+
+    except Exception:
+        logger.debug("Could not read Mistral embedding usage", exc_info=True)
+        return {}
+
+
+@contextmanager
+def embedding_span(model: str, input: str):
+    """Trace one Mistral embedding call, yielding a callable to record its response.
+
+    Attribute vocabulary matches what logfire's OpenAI integration emits for
+    `/embeddings`, so these spans get the same treatment as any other LLM span.
+    """
+    with EMBEDDINGS_TRACER.start_as_current_span(
+        f"Embedding Creation with {model!r}",
+        kind=SpanKind.CLIENT,
+        attributes={
+            "gen_ai.operation.name": "embeddings",
+            "gen_ai.system": "mistral",
+            "gen_ai.provider.name": "mistral",
+            "gen_ai.request.model": model,
+            "request_data": json.dumps({"model": model, "input": [input]}),
+            TAGS_KEY: ["LLM"],
+            JSON_SCHEMA_KEY: EMBEDDING_JSON_SCHEMA,
+        },
+    ) as span:
+
+        def record(response) -> None:
+            span.set_attributes(_embedding_response_attributes(response))
+
+        yield record

--- a/dsview/model_utils/providers/anthropic.py
+++ b/dsview/model_utils/providers/anthropic.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Union
 
+import logfire
 import instructor
 import numpy as np
 from anthropic import Anthropic, AsyncAnthropic
@@ -14,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 # Fixed name is fine: each batch request carries its own independent tool scope.
 BATCH_TOOL_NAME = "extract_data"
+
+logfire.instrument_anthropic()
 
 
 class AnthropicProvider(ModelProvider):
@@ -39,14 +42,18 @@ class AnthropicProvider(ModelProvider):
         messages: list[dict[str, str]],
         structured_output_class: type[BaseModel] = None,
     ) -> Union[str, BaseModel]:
+        system, other_messages = self._split_system_message(messages)
+        system_kwargs = {"system": system} if system is not None else {}
+
         if structured_output_class is not None:
             struct_client = instructor.from_anthropic(self.client)
 
             chat_response = struct_client.messages.create(
                 model=self.model_config.chat_model,
-                messages=messages,
+                messages=other_messages,
                 # max_tokens=1_024,
                 response_model=structured_output_class,
+                **system_kwargs,
                 **self.model_config.model_specific_config,
             )
 
@@ -55,7 +62,8 @@ class AnthropicProvider(ModelProvider):
             chat_response = self.client.messages.create(
                 model=self.model_config.chat_model,
                 # max_tokens=1_024,
-                messages=messages,
+                messages=other_messages,
+                **system_kwargs,
                 **self.model_config.model_specific_config,
             )
 
@@ -66,21 +74,26 @@ class AnthropicProvider(ModelProvider):
         messages: list[dict[str, str]],
         structured_output_class: type[BaseModel] = None,
     ) -> Union[str, BaseModel]:
+        system, other_messages = self._split_system_message(messages)
+        system_kwargs = {"system": system} if system is not None else {}
+
         if structured_output_class is not None:
             struct_client = instructor.AsyncInstructor(
                 client=self.async_client,
                 create=instructor.patch(
                     create=self.async_client.messages.create,
                     mode=instructor.Mode.ANTHROPIC_TOOLS,
+                    provider=instructor.Provider.ANTHROPIC,
                 ),
                 mode=instructor.Mode.ANTHROPIC_TOOLS,
             )
 
             chat_response = await struct_client.chat.completions.create(
                 model=self.model_config.chat_model,
-                messages=messages,
+                messages=other_messages,
                 # max_tokens=1_024,
                 response_model=structured_output_class,
+                **system_kwargs,
                 **self.model_config.model_specific_config,
             )
 
@@ -89,7 +102,8 @@ class AnthropicProvider(ModelProvider):
             chat_response = await self.async_client.messages.create(
                 model=self.model_config.chat_model,
                 # max_tokens=1_024,
-                messages=messages,
+                messages=other_messages,
+                **system_kwargs,
                 **self.model_config.model_specific_config,
             )
 

--- a/dsview/model_utils/providers/mistral.py
+++ b/dsview/model_utils/providers/mistral.py
@@ -7,13 +7,17 @@ import numpy as np
 from mistralai.client import Mistral
 from mistralai.client.models import File
 from mistralai.extra import response_format_from_pydantic_model
+from openinference.instrumentation.mistralai import MistralAIInstrumentor
 from pydantic import BaseModel, ValidationError
 
 from dsview.config import ModelConfig
 
 from ..model_provider import ModelProvider, native_batch_disabled
+from ..observability import embedding_span
 
 logger = logging.getLogger(__name__)
+
+MistralAIInstrumentor().instrument()
 
 # Parity with the max_tokens previously configured on the instructor client.
 STRUCTURED_OUTPUT_MAX_TOKENS = 10_000
@@ -41,18 +45,22 @@ class MistralProvider(ModelProvider):
         self.client.models.retrieve(model_id=model_name)
 
     def _embed(self, input: str) -> np.ndarray:
-        response = self.client.embeddings.create(
-            model=self.model_config.embedding_model,
-            inputs=[input],
-        )
+        with embedding_span(self.model_config.embedding_model, input) as record:
+            response = self.client.embeddings.create(
+                model=self.model_config.embedding_model,
+                inputs=[input],
+            )
+            record(response)
 
         return np.array(response.data[0].embedding)
 
     async def _async_embed(self, input: str) -> np.ndarray:
-        response = await self.client.embeddings.create_async(
-            model=self.model_config.embedding_model,
-            inputs=[input],
-        )
+        with embedding_span(self.model_config.embedding_model, input) as record:
+            response = await self.client.embeddings.create_async(
+                model=self.model_config.embedding_model,
+                inputs=[input],
+            )
+            record(response)
 
         return np.array(response.data[0].embedding)
 

--- a/dsview/obsidian/write_notes.py
+++ b/dsview/obsidian/write_notes.py
@@ -57,7 +57,7 @@ def update_topic_note(topic: ExtractionTopic, old_name: str, old_type: str):
     The pre-merge identity is passed in rather than read back from the SQLAlchemy
     attribute history, which any flush resets (see #55).
     """
-    logger.warning("Updating topic note %s to %s", old_name, topic.name)
+    logger.info("Updating topic note %s to %s", old_name, topic.name)
 
     # Deleting old note. A merge often keeps the name and type, in which case
     # this is the note write_topic_note is about to write again

--- a/kubernetes/dsview_deployment.yaml
+++ b/kubernetes/dsview_deployment.yaml
@@ -430,6 +430,11 @@ spec:
                 secretKeyRef:
                   name: dsview-secret
                   key: GITHUB_TOKEN
+            - name: LOGFIRE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dsview-secret
+                  key: LOGFIRE_TOKEN
 
 ---
 # Dashboard Deployment
@@ -655,3 +660,8 @@ spec:
                 secretKeyRef:
                   name: dsview-secret
                   key: MISTRAL_API_KEY
+            - name: LOGFIRE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dsview-secret
+                  key: LOGFIRE_TOKEN

--- a/mcp.Dockerfile
+++ b/mcp.Dockerfile
@@ -11,4 +11,4 @@ RUN uv sync --no-default-groups --group mcp --frozen --no-cache
 
 EXPOSE 8000
 
-CMD ["uv", "run", "python", "dsview/mcp/server.py"]
+CMD ["uv", "run", "dsview/mcp/server.py"]

--- a/notebooks/explore_duplicates.py
+++ b/notebooks/explore_duplicates.py
@@ -25,7 +25,7 @@ def _(engine, mo):
         f"""
         SELECT * FROM extraction.extractionresult
         """,
-        engine=engine
+        engine=engine,
     )
     return (extraction_results,)
 
@@ -44,7 +44,9 @@ def _(extraction_results):
 
 @app.cell
 def _(extraction_results):
-    extraction_results[extraction_results.duplicated(subset=["title_lower"], keep=False)]
+    extraction_results[
+        extraction_results.duplicated(subset=["title_lower"], keep=False)
+    ]
     return
 
 
@@ -60,7 +62,7 @@ def _(engine, mo):
         f"""
         SELECT * FROM content.inputcontent WHERE id IN (643, 744, 745)
         """,
-        engine=engine
+        engine=engine,
     )
     return
 
@@ -71,7 +73,7 @@ def _(engine, mo):
         f"""
         SELECT * FROM extraction.extractiontopic
         """,
-        engine=engine
+        engine=engine,
     )
     return (extraction_topics,)
 
@@ -130,7 +132,7 @@ def _(engine, mo):
         LIMIT
             100
         """,
-        engine=engine
+        engine=engine,
     )
     return
 
@@ -141,7 +143,7 @@ def _(engine, mo):
         f"""
         SELECT * FROM content.failedingestion
         """,
-        engine=engine
+        engine=engine,
     )
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "beautifulsoup4>=4.13.5",
     "igraph>=1.0.0",
     "markdown-it-py>=3.0.0",
+    "logfire[fastapi,requests,sqlalchemy]>=4.40.0",
+    "openinference-instrumentation-mistralai>=2.0",
+    "youtube-transcript-api>=1.2.4",
 ]
 
 [tool.uv]
@@ -78,7 +81,6 @@ labels = [
     "streamlit>=1.41.1",
 ]
 api = [
-    "youtube-transcript-api>=1.2.4",
     "docling>=2.113.0",
     "fastapi[standard]>=0.139.0",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,18 @@ def client(monkeypatch):
     monkeypatch.setattr(
         api.ingest_pipeline, "get_existing_content", lambda link, session: None
     )
+    # /ingest now commits the content row before returning 202 and the background
+    # task re-reads it by id; stub both so no real DB access happens.
+    monkeypatch.setattr(
+        api.ingest_pipeline, "register_content", lambda content, session: content
+    )
+    monkeypatch.setattr(
+        api,
+        "get_content_by_id",
+        lambda content_id, session: type(
+            "FakeContent", (), {"id": content_id, "link": "https://example.com/post"}
+        )(),
+    )
     monkeypatch.setattr(
         api.ingest_pipeline, "async_ingest_content", AsyncMock(return_value=None)
     )
@@ -50,10 +62,16 @@ def test_ingest_returns_202_immediately(client):
     assert response.json()["status"] == "processing"
 
 
-def test_ingest_completes_in_background_and_uploads_vault_changes(client):
+def test_ingest_completes_in_background_and_uploads_vault_changes(client, monkeypatch):
+    # The vault push only happens when a github vault is configured, which is a
+    # local-config detail; pin it so the test doesn't depend on config/storage.yaml.
+    monkeypatch.setattr(
+        api.vault_config.github_vault, "repository", "owner/dsview_vault"
+    )
+
     done = threading.Event()
 
-    async def slow_ingest(content, session):
+    async def slow_ingest(content, session, already_saved=False):
         await asyncio.sleep(0.05)
 
     async def upload_and_signal(commit_message):
@@ -103,10 +121,29 @@ def test_log_background_ingest_result_logs_any_exception(caplog):
     assert "Background ingest task failed" in caplog.text
 
 
-def test_ingest_status_pending_when_content_unknown(client):
+def test_ingest_status_unknown_when_link_was_never_submitted(client):
+    # /ingest commits the content row before returning, so a missing row can only
+    # mean this link was never submitted.
     response = client.get("/ingest/status", params={"link": "https://example.com/post"})
 
-    assert response.status_code == 200
+    assert response.status_code == 404
+    assert response.json()["status"] == "unknown"
+
+
+def test_ingest_status_pending_while_ingestion_is_running(client, monkeypatch):
+    fake_content = type("FakeContent", (), {"id": 1})()
+
+    monkeypatch.setattr(
+        api.ingest_pipeline, "get_existing_content", lambda link, session: fake_content
+    )
+    monkeypatch.setattr(api, "get_failed_ingestion", lambda content_id, session: None)
+    monkeypatch.setattr(
+        api, "get_content_extraction", lambda content_id, session: [[], [], []]
+    )
+
+    response = client.get("/ingest/status", params={"link": "https://example.com/post"})
+
+    assert response.status_code == 202
     assert response.json() == {"status": "pending"}
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,145 @@
+import json
+
+import logfire
+from mistralai.client.models import EmbeddingResponse, EmbeddingResponseData, UsageInfo
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from dsview.model_utils import observability
+from dsview.model_utils.observability import (
+    MISTRAL_SCOPE,
+    MistralUsageSpanProcessor,
+    embedding_span,
+)
+
+MISTRAL_CHAT_ATTRIBUTES = {
+    "llm.model_name": "mistral-small-2603",
+    "llm.token_count.prompt": 1000,
+    "llm.token_count.completion": 500,
+}
+
+
+def emit_span(scope: str, attributes: dict):
+    """Run one span through a real logfire pipeline and return what got exported.
+
+    Going through logfire rather than a bare TracerProvider matters: logfire wraps
+    everything in a MainSpanProcessorWrapper that rebuilds each span, leaving the
+    span's attributes an immutable mappingproxy by the time our processor sees it.
+    `local=True` keeps this off the global tracer provider.
+    """
+    exporter = InMemorySpanExporter()
+
+    instance = logfire.configure(
+        local=True,
+        send_to_logfire=False,
+        console=False,
+        additional_span_processors=[
+            MistralUsageSpanProcessor(),
+            SimpleSpanProcessor(exporter),
+        ],
+    )
+
+    tracer = instance.config.get_tracer_provider().get_tracer(scope)
+    with tracer.start_as_current_span("chat") as span:
+        span.set_attributes(attributes)
+
+    return exporter.get_finished_spans()[0].attributes
+
+
+def test_mistral_usage_is_translated_to_semconv():
+    attributes = emit_span(MISTRAL_SCOPE, MISTRAL_CHAT_ATTRIBUTES)
+
+    assert attributes["gen_ai.request.model"] == "mistral-small-2603"
+    assert attributes["gen_ai.usage.input_tokens"] == 1000
+    assert attributes["gen_ai.usage.output_tokens"] == 500
+    assert attributes["gen_ai.system"] == "mistral"
+    assert attributes["gen_ai.provider.name"] == "mistral"
+
+    # The originals stay put, so the OpenInference view of the span is unchanged.
+    assert attributes["llm.token_count.prompt"] == 1000
+
+
+def test_other_scopes_are_left_alone():
+    attributes = emit_span(
+        "openinference.instrumentation.langchain", MISTRAL_CHAT_ATTRIBUTES
+    )
+
+    assert "gen_ai.usage.input_tokens" not in attributes
+    assert "gen_ai.system" not in attributes
+
+
+def test_spans_without_token_counts_are_left_alone():
+    # Not a model request: tagging it would double count cost in the UI.
+    attributes = emit_span(MISTRAL_SCOPE, {"llm.model_name": "mistral-small-2603"})
+
+    assert "gen_ai.request.model" not in attributes
+    assert "gen_ai.system" not in attributes
+
+
+def embedding_response(prompt_tokens: int = 12) -> EmbeddingResponse:
+    return EmbeddingResponse(
+        id="emb-1",
+        object="list",
+        model="mistral-embed",
+        usage=UsageInfo(
+            prompt_tokens=prompt_tokens, completion_tokens=0, total_tokens=prompt_tokens
+        ),
+        data=[EmbeddingResponseData(object="embedding", embedding=[0.1, 0.2], index=0)],
+    )
+
+
+def emit_embedding_span(response, monkeypatch) -> dict:
+    exporter = InMemorySpanExporter()
+
+    instance = logfire.configure(
+        local=True,
+        send_to_logfire=False,
+        console=False,
+        additional_span_processors=[SimpleSpanProcessor(exporter)],
+    )
+
+    # `embedding_span` emits through the global tracer provider, which logfire only
+    # installs when it isn't local; point it at this instance rather than letting a
+    # test reconfigure the whole process.
+    monkeypatch.setattr(
+        observability,
+        "EMBEDDINGS_TRACER",
+        instance.config.get_tracer_provider().get_tracer("dsview.embeddings"),
+    )
+
+    with embedding_span("mistral-embed", "some text to embed") as record:
+        record(response)
+
+    return exporter.get_finished_spans()[0].attributes
+
+
+def test_embedding_span_carries_usage_and_llm_tag(monkeypatch):
+    attributes = emit_embedding_span(embedding_response(), monkeypatch)
+
+    assert attributes["gen_ai.operation.name"] == "embeddings"
+    assert attributes["gen_ai.system"] == "mistral"
+    assert attributes["gen_ai.provider.name"] == "mistral"
+    assert attributes["gen_ai.request.model"] == "mistral-embed"
+    assert attributes["gen_ai.response.model"] == "mistral-embed"
+    assert attributes["gen_ai.usage.input_tokens"] == 12
+    assert attributes["gen_ai.usage.output_tokens"] == 0
+    assert attributes["gen_ai.embeddings.dimension.count"] == 2
+    assert attributes["logfire.tags"] == ("LLM",)
+
+
+def test_embedding_span_records_the_input_but_not_the_vector(monkeypatch):
+    attributes = emit_embedding_span(embedding_response(), monkeypatch)
+
+    assert json.loads(attributes["request_data"])["input"] == ["some text to embed"]
+    assert json.loads(attributes["response_data"]) == {
+        "usage": {"prompt_tokens": 12, "completion_tokens": 0, "total_tokens": 12}
+    }
+
+
+def test_unreadable_response_does_not_break_the_embedding_call(monkeypatch):
+    # Observability must never take down a live call - a response we can't read just
+    # loses its usage attributes.
+    attributes = emit_embedding_span(object(), monkeypatch)
+
+    assert "gen_ai.usage.input_tokens" not in attributes
+    assert attributes["gen_ai.request.model"] == "mistral-embed"

--- a/uv.lock
+++ b/uv.lock
@@ -264,6 +264,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1079,12 +1088,14 @@ dependencies = [
     { name = "duckdb" },
     { name = "igraph" },
     { name = "instructor", extra = ["anthropic"] },
+    { name = "logfire", extra = ["fastapi", "requests", "sqlalchemy"] },
     { name = "markdown-it-py" },
     { name = "mistralai" },
     { name = "numpy" },
     { name = "ollama" },
     { name = "omegaconf" },
     { name = "openai" },
+    { name = "openinference-instrumentation-mistralai" },
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -1096,13 +1107,13 @@ dependencies = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "typer" },
+    { name = "youtube-transcript-api" },
 ]
 
 [package.dev-dependencies]
 api = [
     { name = "docling" },
     { name = "fastapi", extra = ["standard"] },
-    { name = "youtube-transcript-api" },
 ]
 dashboard = [
     { name = "altair" },
@@ -1139,12 +1150,14 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.3.2" },
     { name = "igraph", specifier = ">=1.0.0" },
     { name = "instructor", extras = ["anthropic"], specifier = ">1.15" },
+    { name = "logfire", extras = ["fastapi", "requests", "sqlalchemy"], specifier = ">=4.40.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "mistralai", specifier = ">=2.6,<3" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "ollama", specifier = ">=0.4.7" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "openai", specifier = ">=1.63.0" },
+    { name = "openinference-instrumentation-mistralai", specifier = ">=2.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.10.3" },
@@ -1156,13 +1169,13 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
     { name = "typer", specifier = ">=0.15.1" },
+    { name = "youtube-transcript-api", specifier = ">=1.2.4" },
 ]
 
 [package.metadata.requires-dev]
 api = [
     { name = "docling", specifier = ">=2.113.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.139.0" },
-    { name = "youtube-transcript-api", specifier = ">=1.2.4" },
 ]
 dashboard = [
     { name = "altair", specifier = ">=5.5.0" },
@@ -1254,6 +1267,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/15/273a4baf8248d6d76220723c3caf039d283774b31a7c46ba686120145b76/eval_type_backport-0.4.0.tar.gz", hash = "sha256:8397d25e6524c2e67b9576bb0636be27dea2192017711220c534ec2de921e9b0", size = 10260, upload-time = "2026-06-02T13:22:06.059Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/a7/bb99bf5e6f78736ddb53480f2c3ff3702ffe2196a7c5e1661c03081d398e/eval_type_backport-0.4.0-py3-none-any.whl", hash = "sha256:ad5e2a8db71b6696a56eafb938b0f5a337d3217f256b8e158b469422b4772b20", size = 6432, upload-time = "2026-06-02T13:22:04.827Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -1684,6 +1706,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/b9/e370d86fea3da13ec0256df30323dd26c0cb9c8c85f0c6ec42ac9df0106b/google_auth-2.55.2.tar.gz", hash = "sha256:97ae7790ff740f2bc9db60eb864a7804f4ac19f5f02c38b3d942f2fea6e9b9ae", size = 361414, upload-time = "2026-07-07T18:43:21.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/c6/02eb5a337ac316a4c30c012e747bad5cea36e1a876efecdf80865541f7d8/google_auth-2.55.2-py3-none-any.whl", hash = "sha256:d715f265f2cafc6a5f1bf0dc19870d20e3119f6f6682785a250bce3d03d38a3b", size = 256778, upload-time = "2026-07-07T18:43:19.52Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
 ]
 
 [[package]]
@@ -2375,6 +2409,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/98/a29133b4728671a175f7d616fab8b1c6e1d8c269d1523581d3160697bfb1/llvmlite-0.48.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d9f952dff6c350c529997423d4fa43abae9722a884ac7ffafc37a3af676e7db", size = 59890119, upload-time = "2026-07-01T18:42:33.88Z" },
     { url = "https://files.pythonhosted.org/packages/1a/cf/7aac11a1f1c7ec54b60c7f6814e87561fb6b55b2f290455d7941eb113420/llvmlite-0.48.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:054aa7d46595935565f276cf0c1659b4f10929c996dd4a606875fae26fba2a23", size = 58343460, upload-time = "2026-07-01T18:42:29.545Z" },
     { url = "https://files.pythonhosted.org/packages/db/41/b96f440c7df5ebba07872cad4e30fbc3560387755b1ea0b629adb76d5ca8/llvmlite-0.48.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d0b3c61aac83b42fb48cc96bffbf57c81b82b2aa92276b7ed6420c814629a99a", size = 42986383, upload-time = "2026-07-01T18:42:37.544Z" },
+]
+
+[[package]]
+name = "logfire"
+version = "4.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "executing" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/71/1ed06d124bd7905f60004d60cbe14c79bda00f0604bf0cb76214f8c96348/logfire-4.40.0.tar.gz", hash = "sha256:f50f9637f9b5cc3eb5f8526e473effa1992d45056c89adc7c821ee7ab2520c75", size = 1260846, upload-time = "2026-08-05T11:26:59.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/65/2ed148a656362ff3b5cce0bfae619cf57ca1df33d0c942b4c1461e57f57c/logfire-4.40.0-py3-none-any.whl", hash = "sha256:0ac2c950968812f27ee68ccec4a362230acffaffb28f04945ee07729d5866fa0", size = 409440, upload-time = "2026-08-05T11:26:56.745Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "opentelemetry-instrumentation-fastapi" },
+]
+requests = [
+    { name = "opentelemetry-instrumentation-requests" },
+]
+sqlalchemy = [
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
 ]
 
 [[package]]
@@ -3511,6 +3574,47 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation"
+version = "0.1.57"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/d1/08bbd17cb66c1d7749802a30a551c132fa0ecdb1169bd13cf47fb8427132/openinference_instrumentation-0.1.57.tar.gz", hash = "sha256:2bd00a1f95ebb8a47d11615c1039128101e4abc0e9722cc4331849afdeb248fc", size = 41183, upload-time = "2026-08-07T14:29:23.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/50/05db6ba8da9fcf1872597f52b66b3894a1e5b78c177a50239e30de008317/openinference_instrumentation-0.1.57-py3-none-any.whl", hash = "sha256:e06f436e93156f5e0cfedf3f34bde1a386f8e00dbff528155a506ce74c72af92", size = 48872, upload-time = "2026-08-07T14:29:21.632Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-mistralai"
+version = "2.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/1c/1b54427069cd07ee8db2eea16ff745ca8811759380d1d6c3e1417d098113/openinference_instrumentation_mistralai-2.0.6.tar.gz", hash = "sha256:352be13dda9ffc70e81fa94fe671e430f205bee07dc71d29e4fae9711267ba31", size = 22386, upload-time = "2026-08-07T14:29:25.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/78/7103a931c8c48d85695dba608293a1323f7d84e30cfdfd06f397c99d8387/openinference_instrumentation_mistralai-2.0.6-py3-none-any.whl", hash = "sha256:768d17e7927cd3c04c7958d22ce4c9832662285206258acf7a2cc8f7ad59c929", size = 20599, upload-time = "2026-08-07T14:29:24.444Z" },
+]
+
+[[package]]
+name = "openinference-semantic-conventions"
+version = "0.1.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/5e/13ffdb2ba436312cda9ed842ce3416fa5961e36a205df9a18a67eef7f9b3/openinference_semantic_conventions-0.1.32.tar.gz", hash = "sha256:2a3e6723ddce37abc5c43d38c6c7ac05b0f2efcfbe75cc0f135ab14ceb0730f7", size = 13980, upload-time = "2026-08-07T14:29:21.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/19/2d096333313d45e5f87d08f903cedc3f7298c5690d2e6c4ef236dc22870e/openinference_semantic_conventions-0.1.32-py3-none-any.whl", hash = "sha256:d06c4716faf7537fbabbb6d34e758ec6b3650a18c037661782fc8c3e9fa90f81", size = 11252, upload-time = "2026-08-07T14:29:19.78Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3536,15 +3640,123 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/4a/bb9d47d7424fc33aeba75275256ae6e6031f44b6a9a3f778d611c0c3ac27/opentelemetry_instrumentation_requests-0.60b1.tar.gz", hash = "sha256:9a1063c16c44a3ba6e81870c4fa42a0fac3ecef5a4d60a11d0976eec9046f3d4", size = 16366, upload-time = "2025-12-11T13:37:12.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/7f/969b59a5acccb4c35317421843d63d7853ad7a18078ca3a9b80c248be448/opentelemetry_instrumentation_requests-0.60b1-py3-none-any.whl", hash = "sha256:eec9fac3fab84737f663a2e08b12cb095b4bd67643b24587a8ecfa3cf4d0ca4c", size = 13141, upload-time = "2025-12-11T13:36:23.696Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-sqlalchemy"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/16/6a4cbff1b7cd86d1e58ffd100255f6da781a88f4a2affdcc3721880191c9/opentelemetry_instrumentation_sqlalchemy-0.60b1.tar.gz", hash = "sha256:b614e874a7c0a692838a0da613d1654e81a0612867836a1f0765e40e9c8cc49b", size = 15317, upload-time = "2025-12-11T13:37:13.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b7/2234bc761c197c7f099f30cad5d50efd8286c59b5b8f45cfd6ba6ebe7d5e/opentelemetry_instrumentation_sqlalchemy-0.60b1-py3-none-any.whl", hash = "sha256:486a5f264d264c44e07e0320e33fd19d09cecd2fd4b99c1064046e77a27d9f9f", size = 14529, upload-time = "2025-12-11T13:36:24.964Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
-version = "1.43.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
 ]
 
 [[package]]
@@ -3572,6 +3784,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
 ]
 
 [[package]]
@@ -6351,77 +6572,61 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.2.2"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
-    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
-    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
-    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
-    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
-    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
-    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
-    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
-    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
-    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
-    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
-    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
-    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
-    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
-    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
-    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **Adds Logfire as the observability backend for the whole project.** API, CLI and MCP all configure it through `setup_logger`, so a manual `dsview ingest`, a full rebuild and an API request land in the same dashboard. Logs route to Logfire alongside spans. Everything degrades to a no-op without `LOGFIRE_TOKEN`
- **Instrumentation is deliberately scoped to the ingestion path, not everything.** Spans cover content loading, PDF conversion, LLM calls, topic ER, index building and vault writes — the stages that are slow, cost money or fail. Left out on purpose: SQLAlchemy (the database is small enough that query traces would be noise) and evaluation runs (MLflow already covers those, and batch calls don't need tracing)
- **Ingestion is now traceable end to end in Logfire.** One trace per URL shows where the time goes, instead of a flat log stream that gave no clue which stage stalled
- **Mistral calls now surface in Logfire's LLM views with tokens and price.** Logfire only ships that translation for a few instrumentation scopes, so this adds a span processor that maps Mistral's attributes onto the GenAI semantic conventions Logfire reads. Embeddings get their own spans, including vector dimensions, since nothing instruments them upstream. Anthropic uses Logfire's native integration
- **`/ingest/status` can now tell "never submitted" from "still working".** Previously both returned pending, so a client polling a typo'd URL waited forever; a wrong link now gets a 404 immediately
- **Fixed a crash in background ingestion** where the status endpoint's URL handling raised on the background path
- **Fixed Anthropic system prompts being sent as a regular message** rather than in the `system` field — they were being treated as ordinary user content