### PR TITLE
Fix ruff 0.16 findings and pin required ruff version

### DIFF
--- a/dsview/cli.py
+++ b/dsview/cli.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import logfire
@@ -83,7 +83,7 @@ def backup():
     backup_path = Path("backup")
     backup_path.mkdir(exist_ok=True)
 
-    output_file = backup_path / f"dsview_{datetime.now():%Y%m%d_%H%M%S}.dump"
+    output_file = backup_path / f"dsview_{datetime.now(UTC):%Y%m%d_%H%M%S}.dump"
     connection_args, env = _pg_connection_args()
 
     run_cmd(
@@ -103,7 +103,7 @@ def ingest(
     link: str = typer.Argument(..., help="URL or link to the content to ingest"),
     already_read: bool = typer.Option(False, help="Mark content as already read"),
     upload_date: datetime = typer.Option(
-        datetime.now(), help="Date when content was uploaded"
+        datetime.now(UTC), help="Date when content was uploaded"
     ),
     read_priority: int = typer.Option(
         0, help="Reading priority (higher numbers = higher priority)"

--- a/dsview/db/ingest/ingest_extraction.py
+++ b/dsview/db/ingest/ingest_extraction.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, datetime
 
 from sqlmodel import Session
 
@@ -117,7 +117,7 @@ def build_er_comparison(
         description_2=topic_2.description,
         fts_score=fts_score,
         vss_distance=vss_distance,
-        decision_date=date.today().isoformat(),
+        decision_date=datetime.now(UTC).date().isoformat(),
         merge_topic=result.merge_topic,
         merge_name=(result.topic.name if result.topic else None),
         merge_type=(result.topic.type if result.topic else None),

--- a/dsview/model_utils/model_provider.py
+++ b/dsview/model_utils/model_provider.py
@@ -89,7 +89,7 @@ class ModelProvider(ABC):
     def _assert_model_exists(self, model_name: str):
         try:
             self._retrieve_model(model_name)
-        except Exception as error:
+        except Exception as error:  # noqa: BLE001 - each provider SDK raises its own exception type here
             raise ProviderConfigurationError(
                 self.model_config.provider, model_name, error
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ mcp = [
 
 
 [tool.ruff]
+required-version = "==0.16.4"
 extend-exclude = ["notebooks"]
 
 [tool.ruff.lint]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import threading
-from datetime import date
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -49,7 +49,7 @@ def client(monkeypatch):
 def _input_content(link: str) -> dict:
     return {
         "link": link,
-        "upload_date": date.today().isoformat(),
+        "upload_date": datetime.now(UTC).date().isoformat(),
     }
 
 

--- a/tests/test_check_vault_sync.py
+++ b/tests/test_check_vault_sync.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import text
 from sqlmodel import Session
@@ -22,7 +22,7 @@ from dsview.obsidian.obsidian_utils import (
 
 
 def _add_content(session: Session, link: str) -> InputContent:
-    content = InputContent(link=link, upload_date=date.today())
+    content = InputContent(link=link, upload_date=datetime.now(UTC).date())
     session.add(content)
     session.commit()
     session.refresh(content)
@@ -40,7 +40,7 @@ def _add_extraction(session: Session, content_id: int, title: str, content_type:
             "content_id": content_id,
             "title": title,
             "content_type": content_type,
-            "extraction_time": datetime.now().isoformat(),
+            "extraction_time": datetime.now(UTC).isoformat(),
         },
     )
     session.commit()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -128,9 +128,11 @@ def test_model_config_2():
 
 
 def test_model_config_3():
-    with generate_config("model.yaml", MODEL_CONFIG_TEST_2):
-        with pytest.raises(ModelConfigurationError):
-            load_model_config()
+    with (
+        generate_config("model.yaml", MODEL_CONFIG_TEST_2),
+        pytest.raises(ModelConfigurationError),
+    ):
+        load_model_config()
 
 
 def test_extraction_config():

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, datetime
 
 from sqlmodel import Session
 
@@ -7,7 +7,7 @@ from dsview.db.schemas import FailedIngestion, InputContent
 
 
 def _saved_content(session: Session) -> InputContent:
-    content = InputContent(link="https://example.com/a", upload_date=date.today())
+    content = InputContent(link="https://example.com/a", upload_date=datetime.now(UTC).date())
     session.add(content)
     session.commit()
     return content


### PR DESCRIPTION
ruff 0.16 enabled a much larger default rule set (DTZ, BLE, SIM, ...) than 0.15, surfacing 9 new findings across dsview/ and tests/:
- Use tz-aware datetime.now(UTC) instead of naive datetime.now()/date.today()
- Silence the intentional blind except in model_provider.py (each provider SDK raises its own exception type at that boundary)
- Merge nested `with` statements in test_config.py

Also set required-version = "==0.16.4" in [tool.ruff] so a stale locally-installed ruff binary fails loudly instead of silently linting with an outdated ruleset, without adding ruff as a project dependency.